### PR TITLE
Discover lint options relative to input location

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,11 +35,15 @@ const runEslint = (paths, opts) => {
 	const config = optionsManager.buildConfig(opts);
 	const engine = new eslint.CLIEngine(config);
 	const report = engine.executeOnFiles(paths, config);
-
 	return processReport(report, opts);
 };
 
-module.exports.lintText = (str, opts) => {
+module.exports.lintText = (str, opts = {}) => {
+	if (opts.stdinFilename && !opts.cwd) {
+		opts.cwd = path.dirname(opts.stdinFilename);
+		opts.filename = opts.stdinFilename;
+	}
+
 	opts = optionsManager.preprocess(opts);
 
 	if (opts.overrides && opts.overrides.length > 0) {
@@ -84,10 +88,17 @@ module.exports.lintText = (str, opts) => {
 	return processReport(report, opts);
 };
 
-module.exports.lintFiles = (patterns, opts) => {
+module.exports.lintFiles = (patterns, opts = {}) => {
+	const isEmptyPatterns = patterns.length === 0;
+
+	if (!isEmptyPatterns && !opts.cwd) {
+		// Use file path rather process.cwd for analysing files
+		const cwd = path.dirname(arrify(patterns)[0]);
+		opts.cwd = cwd;
+	}
+
 	opts = optionsManager.preprocess(opts);
 
-	const isEmptyPatterns = patterns.length === 0;
 	const defaultPattern = `**/*.{${opts.extensions.join(',')}}`;
 	const ignoreFilter = optionsManager.getGitIgnoreFilter(opts);
 

--- a/index.js
+++ b/index.js
@@ -35,10 +35,12 @@ const runEslint = (paths, opts) => {
 	const config = optionsManager.buildConfig(opts);
 	const engine = new eslint.CLIEngine(config);
 	const report = engine.executeOnFiles(paths, config);
+
 	return processReport(report, opts);
 };
 
-module.exports.lintText = (str, opts = {}) => {
+module.exports.lintText = (str, opts) => {
+	opts = opts || {};
 	if (opts.stdinFilename && !opts.cwd) {
 		opts.cwd = path.dirname(opts.stdinFilename);
 		opts.filename = opts.stdinFilename;
@@ -88,9 +90,10 @@ module.exports.lintText = (str, opts = {}) => {
 	return processReport(report, opts);
 };
 
-module.exports.lintFiles = (patterns, opts = {}) => {
+module.exports.lintFiles = (patterns, opts) => {
 	const isEmptyPatterns = patterns.length === 0;
 
+	opts = opts || {};
 	if (!isEmptyPatterns && !opts.cwd) {
 		// Use file path rather process.cwd for analysing files
 		const cwd = path.dirname(arrify(patterns)[0]);

--- a/test/lint-files.js
+++ b/test/lint-files.js
@@ -94,3 +94,9 @@ test('multiple negative patterns should act as positive patterns', async t => {
 
 	t.deepEqual(paths, ['!!unicorn.js', '!unicorn.js']);
 });
+
+test('respect file path for option discovery rather than process.cwd', async t => {
+	const filename = path.join(__dirname, 'fixtures', 'overrides', 'index.js');
+	const {results} = await fn.lintFiles(filename, {});
+	t.is(results[0].errorCount, 0);
+});

--- a/test/lint-text.js
+++ b/test/lint-text.js
@@ -196,3 +196,11 @@ test('lint negatively gitignored files', async t => {
 
 	t.true(results[0].errorCount > 0);
 });
+
+test('respect stdinFilename path for option discovery', async t => {
+	const cwd = path.join(__dirname, 'fixtures/overrides');
+	const filename = path.join(cwd, 'index.js');
+	const text = await readFile(filename, 'utf-8');
+	const {results} = fn.lintText(text, {stdinFilename: filename});
+	t.is(results[0].errorCount, 0);
+});


### PR DESCRIPTION
This commit allows running commands from any location and still have
`xo` to analyse files against the input directory rather than where the
command is initiated (`process.cwd`)

Previously commands like:

```bash
cd /Users/foo/Desktop
xo /Users/foo/Develop/example.com/lib/index.js
```

or

```bash
cd /Users/foo/Desktop
FILE=/Users/foo/Develop/example.com/lib/index.js
cat $FILE | xo --stdin --stdin-filename $FILE
```

The above would lookup for `xo` options under `package.json` relative to
`/Users/foo/Desktop` rather than where the file is located, which is not
the intended behaviour.

This commit tries to solve that always analyse against the command
input location instead, whener available.

This has benefits such as solving issues like
https://github.com/sindresorhus/xo/issues/223 and
https://github.com/okonet/lint-staged/issues/369
  
---

Fixes #223