### PR TITLE
Allow to override default ignore with negative patterns

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -323,15 +323,9 @@ const groupConfigs = (paths, baseOptions, overrides) => {
 	return arr;
 };
 
-const getIgnores = opts => {
-	opts.ignores = DEFAULT_IGNORE.concat(opts.ignores || []);
-	return opts;
-};
-
 const preprocess = opts => {
 	opts = mergeWithPkgConf(opts);
 	opts = normalizeOpts(opts);
-	opts = getIgnores(opts);
 	opts.extensions = DEFAULT_EXTENSION.concat(opts.extensions || []);
 
 	return opts;
@@ -348,4 +342,3 @@ module.exports.mergeApplicableOverrides = mergeApplicableOverrides;
 module.exports.groupConfigs = groupConfigs;
 module.exports.preprocess = preprocess;
 module.exports.emptyOptions = emptyOptions;
-module.exports.getIgnores = getIgnores;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
 		"get-stdin": "^5.0.0",
 		"globby": "^7.1.1",
 		"has-flag": "^3.0.0",
-		"lodash.isequal": "^4.4.0",
 		"lodash.mergewith": "^4.6.0",
 		"meow": "^4.0.0",
 		"multimatch": "^2.1.0",

--- a/test/lint-text.js
+++ b/test/lint-text.js
@@ -16,10 +16,18 @@ test('.lintText()', t => {
 
 test('default `ignores`', t => {
 	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
-		filename: 'node_modules/ignored/index.js'
+		filename: 'test/fixtures/index.js'
 	});
 	t.is(result.errorCount, 0);
 	t.is(result.warningCount, 0);
+});
+
+test('overrride default `ignores`', t => {
+	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
+		filename: 'test/fixtures/index.js',
+		ignores: '!{test/,}fixture{s,}/**'
+	});
+	t.true(result.errorCount > 0);
 });
 
 test('`ignores` option', t => {

--- a/test/main.js
+++ b/test/main.js
@@ -45,8 +45,7 @@ test('overrides fixture', async t => {
 	await t.notThrows(main([], {cwd}));
 });
 
-// https://github.com/sindresorhus/xo/issues/65
-test.failing('ignores fixture', async t => {
+test('override ignores', async t => {
 	const cwd = path.join(__dirname, 'fixtures/ignores');
 	await t.throws(main([], {cwd}));
 });


### PR DESCRIPTION
Fix #65

In `lintFiles` instead of passing the ignores to globby `ignores` options, this PR invert the ignores patterns and pass them to globby within the pattern array.
The ignores pattern from the `ignores` options are concatenated to the default one so they can override them.

We have to invert the ignores patterns and pass them to the `pattern` parameter because node glob doesn't handle opposed patterns in the `ignore` options. In other words passing `['dir/**', '!dir/**']` or `['dir/**']` in the `ignore` options exclude the files in `dir` in both case. But passing `['!dir/**', 'dir/**']` in the `pattern` argument does include the files in `dir`.
