### PR TITLE
Disable `enforceForRenamedProperties` for `prefer-destructuring`

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -76,7 +76,7 @@ const ENGINE_RULES = {
 		'5.0.0': 'error'
 	},
 	'prefer-destructuring': {
-		'6.0.0': ['error', {array: true, object: true}, {enforceForRenamedProperties: true}]
+		'6.0.0': ['error', {array: true, object: true}]
 	},
 	'unicorn/no-new-buffer': {
 		'5.10.0': 'error'

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -200,9 +200,7 @@ test('buildConfig: engines: >=6', t => {
 	t.is(config.rules['unicorn/prefer-spread'], 'error');
 	// Include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], 'error');
-	t.deepEqual(config.rules['prefer-destructuring'], [
-		'error', {array: true, object: true}, {enforceForRenamedProperties: true}
-	]);
+	t.deepEqual(config.rules['prefer-destructuring'], ['error', {array: true, object: true}]);
 	// Do not include rules for Node.js 8 and above
 	t.is(config.rules['promise/prefer-await-to-then'], undefined);
 });
@@ -214,9 +212,7 @@ test('buildConfig: engines: >=8', t => {
 	t.is(config.rules['unicorn/prefer-spread'], 'error');
 	// Include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], 'error');
-	t.deepEqual(config.rules['prefer-destructuring'], [
-		'error', {array: true, object: true}, {enforceForRenamedProperties: true}
-	]);
+	t.deepEqual(config.rules['prefer-destructuring'], ['error', {array: true, object: true}]);
 	// Include rules for Node.js 8 and above
 	t.is(config.rules['promise/prefer-await-to-then'], 'error');
 });


### PR DESCRIPTION
Disabling due to eslint/eslint#9970