### PR TITLE
Disable parsing of prettier CLI option

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,9 +75,9 @@ const cli = meow(`
 		// 	type: 'boolean',
 		// 	default: true
 		// },
-		prettier: {
-			type: 'boolean'
-		},
+		// prettier: {
+		// 	type: 'boolean'
+		// },
 		nodeVersion: {
 			type: 'string'
 		},


### PR DESCRIPTION
It's `meow` set all boolean option to `false` if they are not set.
That means all boolean options set in `package.json` will be overwritten.

 The `semicolon` options is commented out for this reason. The `pretiter` one is in the same situation...