### PR TITLE
Do not add indent rule when `prettier` option is true

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -182,7 +182,7 @@ const buildConfig = opts => {
 		}
 	}
 
-	if (opts.space) {
+	if (opts.space && !opts.prettier) {
 		config.rules.indent = ['error', spaces, {SwitchCase: 1}];
 
 		// Only apply if the user has the React plugin

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -122,6 +122,8 @@ test('buildConfig: prettier: true, space: 4', t => {
 		tabWidth: 4,
 		trailingComma: 'es5'
 	}]);
+	// Indent rule is not enabled
+	t.is(config.rules.indent, undefined);
 });
 
 test('buildConfig: prettier: true, esnext: false', t => {
@@ -137,6 +139,23 @@ test('buildConfig: prettier: true, esnext: false', t => {
 		tabWidth: 2,
 		trailingComma: 'none'
 	}]);
+});
+
+test('buildConfig: prettier: true, space: true', t => {
+	const config = manager.buildConfig({prettier: true, space: true});
+
+	// Sets `useTabs` and `tabWidth` options in `prettier/prettier` rule based on the XO `space` options
+	t.deepEqual(config.rules['prettier/prettier'], ['error', {
+		useTabs: false,
+		bracketSpacing: false,
+		jsxBracketSameLine: false,
+		semi: true,
+		singleQuote: true,
+		tabWidth: 2,
+		trailingComma: 'es5'
+	}]);
+	// Indent rule is not enabled
+	t.is(config.rules.indent, undefined);
 });
 
 test('buildConfig: engines: undefined', t => {


### PR DESCRIPTION
In the specific case of both `prettier` and `space` being `true`, the indent rules is customized by XO.

Rules defined in the `rules` property override the one defined in a config file (in this case `eslint-config-prettier`). So it ends up in a situation in which the number of space to use is handled by both `prettier` and the eslint `indent` rules. In some cases it creates a conflict.

With this change the `indent` rule is set only when `prettier` is `false`.
