### PR TITLE
Don't ignore fixture directories by default

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -18,9 +18,6 @@ const DEFAULT_IGNORE = [
 	'{tmp,temp}/**',
 	'**/*.min.js',
 	'**/bundle.js',
-	'fixture{-*,}.{js,jsx}',
-	'fixture{s,}/**',
-	'{test,tests,spec,__tests__}/fixture{s,}/**',
 	'vendor/**',
 	'dist/**'
 ];


### PR DESCRIPTION
Initially I thought it would be a good idea, but turns out I actually want to lint most fixture files too.

For example, in AVA, we ended up having to explicitly specify it: https://github.com/avajs/ava/blob/a76d462b4cdccd86028e8c9b1bbf84f12af8ab84/package.json#L13

Another example, here it would also have been useful to lint fixtures: https://github.com/sindresorhus/electron-timber/pull/10#discussion_r186282242