### PR TITLE
Upgrade to ESLint 5

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -34,6 +34,7 @@ const DEFAULT_CONFIG = {
 	useEslintrc: false,
 	cache: true,
 	cacheLocation: path.join(os.homedir() || os.tmpdir(), '.xo-cache/'),
+	globInputPaths: false,
 	baseConfig: {
 		extends: [
 			'xo',
@@ -68,6 +69,9 @@ const DEFAULT_CONFIG = {
 const ENGINE_RULES = {
 	'promise/prefer-await-to-then': {
 		'7.6.0': 'error'
+	},
+	'prefer-object-spread': {
+		'8.0.0': 'error'
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
 	"dependencies": {
 		"arrify": "^1.0.1",
 		"debug": "^3.1.0",
-		"eslint": "^4.19.1",
+		"eslint": "^5.0.0",
 		"eslint-config-prettier": "^2.9.0",
-		"eslint-config-xo": "^0.22.0",
+		"eslint-config-xo": "^0.23.0",
 		"eslint-formatter-pretty": "^1.3.0",
 		"eslint-plugin-ava": "^4.5.0",
 		"eslint-plugin-import": "^2.11.0",


### PR DESCRIPTION
https://eslint.org/blog/2018/06/eslint-v5.0.0-released