### PR TITLE
Fix CLI's `--space` option parsing

### DIFF
--- a/main.js
+++ b/main.js
@@ -114,6 +114,20 @@ updateNotifier({pkg: cli.pkg}).notify();
 
 const {input, flags: opts} = cli;
 
+// Make data types for `opts.space` match those of the API
+if (typeof opts.space === 'string') {
+	if (/^\d+$/.test(opts.space)) {
+		opts.space = parseInt(opts.space, 10);
+	} else if (opts.space) {
+		// Assume `opts.space` was set to a filename when run as `xo --space file.js`
+		input.push(opts.space);
+	}
+
+	if (typeof opts.space !== 'number') {
+		opts.space = true;
+	}
+}
+
 const log = report => {
 	const reporter = opts.reporter ? xo.getFormatter(opts.reporter) : formatterPretty;
 

--- a/main.js
+++ b/main.js
@@ -115,15 +115,19 @@ updateNotifier({pkg: cli.pkg}).notify();
 const {input, flags: opts} = cli;
 
 // Make data types for `opts.space` match those of the API
+// Check for string type because `xo --no-space` sets `opts.space` to `false`
 if (typeof opts.space === 'string') {
 	if (/^\d+$/.test(opts.space)) {
 		opts.space = parseInt(opts.space, 10);
-	} else if (opts.space) {
-		// Assume `opts.space` was set to a filename when run as `xo --space file.js`
-		input.push(opts.space);
-	}
-
-	if (typeof opts.space !== 'number') {
+	} else if (opts.space === 'true') {
+		opts.space = true;
+	} else if (opts.space === 'false') {
+		opts.space = false;
+	} else {
+		if (opts.space !== '') {
+			// Assume `opts.space` was set to a filename when run as `xo --space file.js`
+			input.push(opts.space);
+		}
 		opts.space = true;
 	}
 }

--- a/test/fixtures/space/one-space.js
+++ b/test/fixtures/space/one-space.js
@@ -1,0 +1,3 @@
+console.log([
+ 1
+]);

--- a/test/fixtures/space/two-spaces.js
+++ b/test/fixtures/space/two-spaces.js
@@ -1,0 +1,3 @@
+console.log([
+  1
+]);

--- a/test/main.js
+++ b/test/main.js
@@ -142,3 +142,11 @@ test('space option as boolean with filename', async t => {
 	// The default space value of 2 was expected
 	t.is(reports[0].errorCount, 0);
 });
+
+test('space option with boolean strings', async t => {
+	const cwd = path.join(__dirname, 'fixtures/space');
+	const trueResult = await t.throws(main(['--space=true'], {cwd}));
+	const falseResult = await t.throws(main(['--space=false'], {cwd}));
+	t.true(trueResult.stdout.includes('Expected indentation of 2 spaces'));
+	t.true(falseResult.stdout.includes('Expected indentation of 1 tab'));
+});

--- a/test/main.js
+++ b/test/main.js
@@ -115,3 +115,30 @@ test('cli option takes precedence over config', async t => {
 	// i.e make sure absent cli flags are not parsed as `false`
 	await t.throws(main(['--stdin'], {input}));
 });
+
+test('space option with number value', async t => {
+	const cwd = path.join(__dirname, 'fixtures/space');
+	const {stdout} = await t.throws(main(['--space=4', 'one-space.js'], {cwd}));
+	t.true(stdout.includes('Expected indentation of 4 spaces'));
+});
+
+test('space option as boolean', async t => {
+	const cwd = path.join(__dirname, 'fixtures/space');
+	const {stdout} = await t.throws(main(['--space'], {cwd}));
+	t.true(stdout.includes('Expected indentation of 2 spaces'));
+});
+
+test('space option as boolean with filename', async t => {
+	const cwd = path.join(__dirname, 'fixtures/space');
+	const {stdout} = await main(['--reporter=json', '--space', 'two-spaces.js'], {
+		cwd,
+		reject: false
+	});
+	const reports = JSON.parse(stdout);
+
+	// Only the specified file was checked (filename was not the value of `space`)
+	t.is(reports.length, 1);
+
+	// The default space value of 2 was expected
+	t.is(reports[0].errorCount, 0);
+});


### PR DESCRIPTION
Overview
========

Ensure that the `space` value, if present, is either a number or a boolean before passing it to the main API.  The space option is intended to act as either a boolean or a number option, but it is implemented as a string option out of necessity, which led to a few bugs.

Bugs fixed
----------

Here are the results of several invocations before and after applying this PR:

### `xo --space=4`

#### Before fix:
* Expect 2-space indents.
  * The value of `space` is the *string* `'4'`.
  * The value is truthy, resulting in the space option being activated.
  * The value is not a number, resulting in the default of 2 being used.

#### Now:
* Expect 4-space indents.
  * The value of `space` is the *number* `4`.

### `xo --space file.js`

#### Before fix:
* Check all files in the CWD and expect 2-space indents.
  * The value of `space` is `'file.js'`.
  * The value is truthy and not a number, so expect 2-space indents.
  * There are no recognized positional recognized, so check all files.
    - This is a subtle bug, since the desired file *is* usually checked, it's just not checked exclusively.

#### Now:
* Check only `file.js` and expect 2-space indents.

### `xo --space`

#### Before fix:
* Expect tab indents.
  * The value of `space` is the empty string.
  * The value is falsey, so it is not used, instead defaulting to tabs.

#### Now:
* Expect 2-space indents.

Edge cases
----------

These are some quirks that are still present after this PR.  Some of them may actually be desired, depending on your viewpoint, others perhaps less so.  Let me know if there are any that you would like me to address.

* `xo --space=false`: `'false'` is treated as a file name and 2-space indents are expected.  It is similar for `--space=true`.
* `xo --space=3.0`: `'3.0'` is treated as a file name and 2-space indents are expected.  The implementation in this PR only recognizes numbers if they contain nothing but digits. This also applies to negative numbers (no `-` allowed).
* The radix is always treated as `10`, even with leading `0`s.
* `xo --space=0`: Tabs will be expected, since the value is falsey.
* There is no check against `Number.MAX_SAFE_INTEGER`, so weird rounding and overflow can happen if someone wants the worst indent ever.
* `xo --space=4 --no-space`: This results in an array of `['4', false]`, so `space` will be truthy, 2-space indents will be expected, and this array will be passed to the main API as if it were a positional argument.
* Since non-number values of `space` are now assumed to be file names (or globs), it is possible to specify a filename before the end of the command line options: `xo --space file.js --quiet another.js`.

References
----------

Some relevant lines elsewhere in the code base:

* Whether to expect tabs or spaces is [based on the truthiness of the space option](https://github.com/xojs/xo/blob/master/lib/options-manager.js#L152), not just its *presence*.
* Setting the number of spaces to something other than the default of 2 [depends on the value being a number](https://github.com/xojs/xo/blob/master/lib/options-manager.js#L127) (not a string, for example).

Closes #339
Possibly relevant to #212 when specifying a file directly after `--space`