### PR TITLE
Add `.cache/` inside a fixture to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 yarn.lock
 !test/fixtures/project/node_modules
+test/fixtures/project/node_modules/.cache
 .nyc_output
 coverage


### PR DESCRIPTION
The `project` fixture includes a `node_modules` directory which is explicitly included in the repo via a negative `.gitignore` pattern. When running `nyc ava` (but curiously not just `ava`), a `.cache` directory is created inside that fixture's `node_modules` directory. This generated cache directory should not be accidentally committed, so let's tell git to ignore it.

After running `npx nyc ava` (or just `npm test`), I end up with this state:

```bash
$ git status -s
?? test/fixtures/project/node_modules/.cache/
```

There are actually some other fixtures that have `node_modules` directories (even if they're empty). They aren't in the repo, but they might be created when running `npm install` or something. Any that have a `node_modules` directory end up with a `.cache` directory after running the tests, but git already ignores them because they don't specifically have a negative pattern defined in `.gitignore` as this one does. Here are all of the instances I'm seeing, in case you're curious:

```bash
$ cd test && find -name .cache
./fixtures/default-options/node_modules/.cache
./fixtures/ignores/node_modules/.cache
./fixtures/overrides/node_modules/.cache
./fixtures/project/node_modules/.cache
```

An alternative fix would be to remove the `!test/fixtures/project/node_modules` line entirely from `.gitignore` and just manually commit the necessary contents of `node_modules` (which at this point is already done).