### PR TITLE
Follow-up: Use cosmiconfig

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -7,6 +7,7 @@ const multimatch = require('multimatch');
 const pathExists = require('path-exists');
 const pkgConf = require('pkg-conf');
 const findCacheDir = require('find-cache-dir');
+const cosmiconfig = require('cosmiconfig');
 const resolveFrom = require('resolve-from');
 const prettier = require('prettier');
 const semver = require('semver');
@@ -142,7 +143,8 @@ const normalizeOptions = options => {
 const mergeWithPkgConf = options => {
 	options = Object.assign({cwd: process.cwd()}, options);
 	options.cwd = path.resolve(options.cwd);
-	const conf = pkgConf.sync('xo', {cwd: options.cwd, skipOnFalse: true});
+	const searchResult = cosmiconfig('xo').searchSync();
+	const conf = searchResult ? searchResult.config : {};
 	const engines = pkgConf.sync('engines', {cwd: options.cwd});
 	return Object.assign({}, conf, {nodeVersion: engines && engines.node && semver.validRange(engines.node)}, options);
 };

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -143,7 +143,7 @@ const normalizeOptions = options => {
 const mergeWithPkgConf = options => {
 	options = Object.assign({cwd: process.cwd()}, options);
 	options.cwd = path.resolve(options.cwd);
-	const searchResult = cosmiconfig('xo').searchSync();
+	const searchResult = cosmiconfig('xo').searchSync(options.cwd);
 	const conf = searchResult ? searchResult.config : {};
 	const engines = pkgConf.sync('engines', {cwd: options.cwd});
 	return Object.assign({}, conf, {nodeVersion: engines && engines.node && semver.validRange(engines.node)}, options);
@@ -339,7 +339,8 @@ const groupConfigs = (paths, baseOptions, overrides) => {
 	const array = [];
 
 	for (const x of paths) {
-		const data = findApplicableOverrides(x, overrides);
+		const relativePath = baseOptions.cwd ? path.relative(baseOptions.cwd, x) : x;
+		const data = findApplicableOverrides(relativePath, overrides);
 
 		if (!map[data.hash]) {
 			const mergedOptions = mergeApplicableOverrides(baseOptions, data.applicable);

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"eslint-formatter-pretty": "^2.0.0",
 		"eslint-plugin-ava": "^5.1.0",
 		"eslint-plugin-import": "^2.14.0",
-		"cosmiconfig": "^5.0.5",
+		"cosmiconfig": "^5.0.7",
 		"eslint-plugin-no-use-extend-native": "^0.3.12",
 		"eslint-plugin-node": "^8.0.0",
 		"eslint-plugin-prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"eslint-formatter-pretty": "^2.0.0",
 		"eslint-plugin-ava": "^5.1.0",
 		"eslint-plugin-import": "^2.14.0",
+		"cosmiconfig": "^5.0.5",
 		"eslint-plugin-no-use-extend-native": "^0.3.12",
 		"eslint-plugin-node": "^8.0.0",
 		"eslint-plugin-prettier": "^3.0.0",


### PR DESCRIPTION
Following up #279 and #331

This PR reuse #331 commits (thanks @j0hnm4r5 !). I opened it to address once and for all a very anoying issue when using `lint-staged` to trigger `xo`. I made all the tests pass, let me know if I need to add some.

Summary:
- use `cosmiconfig` instead of `pkg-conf` to fetch xo config
- give a relative path to `findApplicableOverrides`

Closes #279
Closes #331 

Fixes #330