### PR TITLE
Use relative path to match applicable overrides

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -337,7 +337,8 @@ const groupConfigs = (paths, baseOptions, overrides) => {
 	const array = [];
 
 	for (const x of paths) {
-		const data = findApplicableOverrides(x, overrides);
+		const relativePath = baseOptions.cwd ? path.relative(baseOptions.cwd, x) : x;
+		const data = findApplicableOverrides(relativePath, overrides);
 
 		if (!map[data.hash]) {
 			const mergedOptions = mergeApplicableOverrides(baseOptions, data.applicable);


### PR DESCRIPTION
Following up #354 

This issue addresses once and for all a very annoying issue when using `lint-staged` to trigger `xo`, where `lint-staged` calls `xo` giving it absolute paths which makes the applicable overrides matching to fail.

Summary:
- give a relative path to `findApplicableOverrides`

Closes #223 