### PR TITLE
Allow xo configuration in extends

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -199,6 +199,59 @@ const buildConfig = options => {
 	);
 	const spaces = normalizeSpaces(options);
 
+	// Copy options, since it will be modified
+	options = Object.assign({}, options);
+
+	// Reading options.extends should be done first
+	if (options.extends && options.extends.length > 0) {
+		// TODO: This logic needs to be improved, preferably use the same code as ESLint
+		// user's configs must be resolved to their absolute paths
+		const configs = options.extends.map(name => {
+			// Don't do anything if it's a filepath
+			if (pathExists.sync(name)) {
+				return name;
+			}
+
+			// Don't do anything if it's a config from a plugin
+			if (name.startsWith('plugin:')) {
+				return name;
+			}
+
+			if (!name.includes('eslint-config-')) {
+				name = `eslint-config-${name}`;
+			}
+
+			const ret = resolveFrom(options.cwd, name);
+
+			if (!ret) {
+				throw new Error(`Couldn't find ESLint config: ${name}`);
+			}
+
+			return ret;
+		});
+
+		// Loop through extends and read its xo value.
+		// If a xo field exists, copy its value to options.
+		configs
+			// Skip non-objects (this means xo configs cannot be put inside unresolved extends).
+			.filter(config => typeof config === 'object')
+			// Pick the xo fields.
+			.map(({xo}) => xo || {})
+			.forEach(({
+				space,
+				semicolon,
+				prettier,
+				nodeVersion,
+				// TODO Extensions are not currently handled, I'm unsure on how to do it.
+				// extensions,
+				esnext
+			}) => {
+				Object.assign(options, {space, semicolon, prettier, nodeVersion, esnext});
+			});
+
+		config.baseConfig.extends = config.baseConfig.extends.concat(configs);
+	}
+
 	if (options.nodeVersion) {
 		for (const rule of Object.keys(ENGINE_RULES)) {
 			// Use the rule value for the highest version that is lower or equal to the oldest version of Node.js supported
@@ -246,36 +299,6 @@ const buildConfig = options => {
 
 	if (options.parser) {
 		config.baseConfig.parser = options.parser;
-	}
-
-	if (options.extends && options.extends.length > 0) {
-		// TODO: This logic needs to be improved, preferably use the same code as ESLint
-		// user's configs must be resolved to their absolute paths
-		const configs = options.extends.map(name => {
-			// Don't do anything if it's a filepath
-			if (pathExists.sync(name)) {
-				return name;
-			}
-
-			// Don't do anything if it's a config from a plugin
-			if (name.startsWith('plugin:')) {
-				return name;
-			}
-
-			if (!name.includes('eslint-config-')) {
-				name = `eslint-config-${name}`;
-			}
-
-			const ret = resolveFrom(options.cwd, name);
-
-			if (!ret) {
-				throw new Error(`Couldn't find ESLint config: ${name}`);
-			}
-
-			return ret;
-		});
-
-		config.baseConfig.extends = config.baseConfig.extends.concat(configs);
 	}
 
 	// If the user sets the `prettier` options then add the `prettier` plugin and config


### PR DESCRIPTION
Allows overriding xo-specific (not ESLint) configurations in extends.

Fixes #352