### PR TITLE
 Turn all paths to `cwd`-relative before linting (fix #223)

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ module.exports.lintFiles = (patterns, options) => {
 			cwd: options.cwd
 		}
 	).then(paths => {
+		paths = paths.map(x => path.relative(options.cwd, x));
+
 		// Filter out unwanted file extensions
 		// For silly users that don't specify an extension in the glob pattern
 		if (!isEmptyPatterns) {

--- a/test/cli-main.js
+++ b/test/cli-main.js
@@ -51,13 +51,13 @@ test('overrides work with relative path', async t => {
 	await t.notThrowsAsync(main([file], {cwd}));
 });
 
-test.failing('overrides work with relative path starting with `./`', async t => {
+test('overrides work with relative path starting with `./`', async t => {
 	const cwd = path.join(__dirname, 'fixtures/overrides');
 	const file = '.' + path.sep + path.join('test', 'bar.js');
 	await t.notThrowsAsync(main([file], {cwd}));
 });
 
-test.failing('overrides work with absolute path', async t => {
+test('overrides work with absolute path', async t => {
 	const cwd = path.join(__dirname, 'fixtures/overrides');
 	const file = path.join(cwd, 'test', 'bar.js');
 	await t.notThrowsAsync(main([file], {cwd}));

--- a/test/cli-main.js
+++ b/test/cli-main.js
@@ -45,6 +45,24 @@ test('overrides fixture', async t => {
 	await t.notThrowsAsync(main([], {cwd}));
 });
 
+test('overrides work with relative path', async t => {
+	const cwd = path.join(__dirname, 'fixtures/overrides');
+	const file = path.join('test', 'bar.js');
+	await t.notThrowsAsync(main([file], {cwd}));
+});
+
+test.failing('overrides work with relative path starting with `./`', async t => {
+	const cwd = path.join(__dirname, 'fixtures/overrides');
+	const file = '.' + path.sep + path.join('test', 'bar.js');
+	await t.notThrowsAsync(main([file], {cwd}));
+});
+
+test.failing('overrides work with absolute path', async t => {
+	const cwd = path.join(__dirname, 'fixtures/overrides');
+	const file = path.join(cwd, 'test', 'bar.js');
+	await t.notThrowsAsync(main([file], {cwd}));
+});
+
 // #65
 test.failing('ignores fixture', async t => {
 	const cwd = path.join(__dirname, 'fixtures/ignores');


### PR DESCRIPTION
Fixes #223