### PR TITLE
Make `--stdin --fix` always return the code even if nothing was fixed

### DIFF
--- a/cli-main.js
+++ b/cli-main.js
@@ -159,7 +159,9 @@ if (options.init) {
 } else if (options.stdin) {
 	getStdin().then(stdin => {
 		if (options.fix) {
-			console.log(xo.lintText(stdin, options).results[0].output);
+			const result = xo.lintText(stdin, options).results[0];
+			// If there is no output, pass the stdin back out
+			console.log(result.output || stdin);
 			return;
 		}
 


### PR DESCRIPTION
An issue I ran into when writing an Emacs function for xo auto-fixing my buffer is when the stdin passed to xo has no code issues, the command `xo --stdin --fix` will return `undefined`, which is a pain in the side. This small fix should hopefully alleviate that with minimal side effects. 

I couldn't find any documentation stating that was to be the desired behavior, and I did find this issue with the same problem from a couple years back: https://github.com/xojs/xo/issues/245

Let me know if I'm PR-ing the wrong project, and I should be investigating ESLint instead!