### PR TITLE
Add webpack plugin to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -385,7 +385,8 @@ XO is based on ESLint. This project started out as just a shareable ESLint confi
 
 - [Gulp](https://github.com/xojs/gulp-xo)
 - [Grunt](https://github.com/xojs/grunt-xo)
-- [webpack](https://github.com/Semigradsky/xo-loader)
+- [webpack loader](https://github.com/Semigradsky/xo-loader)
+- [webpack plugin](https://github.com/nstanard/xo-webpack-plugin)
 - [Metalsmith](https://github.com/blainsmith/metalsmith-xo)
 - [Fly](https://github.com/lukeed/fly-xo)
 


### PR DESCRIPTION
I've created a basic webpack plugin for XO to be used. This is brand new - I was having trouble with the loader one and wanted it to be simpler to install and use. I have plans to add more features as well - but I wanted to get this link up on XO.