### PR TITLE
Disable `no-nested-ternary` when Prettier is used

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -304,6 +304,8 @@ const buildConfig = options => {
 	if (options.prettier) {
 		// Disable formatting rules conflicting with Prettier
 		config.rules['unicorn/number-literal-case'] = 'off';
+		// Can be re-enabled when https://github.com/prettier/prettier/issues/4157 is fixed
+		config.rules['unicorn/no-nested-ternary'] = 'off';
 		// The prettier plugin uses Prettier to format the code with `--fix`
 		config.plugins = config.plugins.concat('prettier');
 		// The prettier config overrides ESLint stylistic rules that are handled by Prettier


### PR DESCRIPTION
This disable the rule `unicorn/no-nested-ternary` when Prettier formatting is enabled.

The reason is that currently Prettier doesn't allow to wrap nested ternary in parenthesis. See https://github.com/prettier/prettier/issues/4157.

This rule can be re-enabled if https://github.com/prettier/prettier/issues/4157 is fixed to allow those parenthesis.