### PR TITLE
Enable `unicorn/prefer-flat-map` only for Node.js >= 11

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -245,6 +245,9 @@ module.exports = {
 		// 'eslint-comments/no-unlimited-disable': 'error',
 
 		'eslint-comments/no-unused-disable': 'error',
-		'eslint-comments/no-unused-enable': 'error'
+		'eslint-comments/no-unused-enable': 'error',
+
+		// Disabled by default, enabled only in Node.js >= 11 in option-manager.js
+		'unicorn/prefer-flat-map': 'off'
 	}
 };

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -107,6 +107,9 @@ const ENGINE_RULES = {
 	},
 	'prefer-named-capture-group': {
 		'10.0.0': 'error'
+	},
+	'unicorn/prefer-flat-map': {
+		'11.0.0': 'error'
 	}
 };
 


### PR DESCRIPTION
`Array.flatMap` is available only on Node.js >= 11: https://node.green/#ES2019-features-Array-prototype--flat--flatMap--Array-prototype-flatMap