### PR TITLE
Fix compatibility with being run in a child process

### DIFF
--- a/cli-main.js
+++ b/cli-main.js
@@ -132,7 +132,7 @@ if (typeof options.space === 'string') {
 const log = report => {
 	const reporter = options.reporter ? xo.getFormatter(options.reporter) : formatterPretty;
 	process.stdout.write(reporter(report.results));
-	process.exit(report.errorCount === 0 ? 0 : 1);
+	process.exitCode = report.errorCount === 0 ? 0 : 1;
 };
 
 // `xo -` => `xo --stdin`


### PR DESCRIPTION
This let's the process exit in the same way but still allows the streams to finish before `child_process` kills it.

Ref: https://github.com/nodejs/node/issues/12921