### PR TITLE
Test: no-unused-disable for capitalized-comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const runEslint = (paths, options) => {
 	const engine = new eslint.CLIEngine(config);
 	const report = engine.executeOnFiles(
 		paths.filter(path => !engine.isPathIgnored(path)),
-		config,
+		config
 	);
 	return processReport(report, options);
 };

--- a/test/cli-main.js
+++ b/test/cli-main.js
@@ -23,8 +23,7 @@ test('fix option with stdin', async t => {
 });
 test('eslint-disable-next-line exact input LF endings', async t => {
 	const {stdout} = await main(['--stdin'], {
-		input: `/* eslint capitalized-comments: ["error"] */
-// eslint-disable-next-line capitalized-comments
+		input: `// eslint-disable-next-line capitalized-comments
 /* spell-checker: disable */
 
 `
@@ -34,7 +33,6 @@ test('eslint-disable-next-line exact input LF endings', async t => {
 test('eslint-disable-next-line exact input CRLF endings', async t => {
 	const {stdout} = await main(['--stdin'], {
 		input: `/* eslint-disable linebreak-style */\r
-/* eslint capitalized-comments: ["error"] */\r
 // eslint-disable-next-line capitalized-comments\r
 /* spell-checker: disable */\r
 
@@ -44,19 +42,19 @@ test('eslint-disable-next-line exact input CRLF endings', async t => {
 });
 test('eslint-disable-next-line one line input LF endings', async t => {
 	const {stdout} = await main(['--stdin'], {
-		input: '/* eslint capitalized-comments: ["error"] */\n// eslint-disable-next-line capitalized-comments\n/* spell-checker: disable */\n'
+		input: '// eslint-disable-next-line capitalized-comments\n/* spell-checker: disable */\n'
 	});
 	t.is(stdout, '');
 });
 test('eslint-disable-next-line one line input CRLF endings', async t => {
 	const {stdout} = await main(['--stdin'], {
-		input: '/* eslint-disable linebreak-style */\r\n/* eslint capitalized-comments: ["error"] */\r\n// eslint-disable-next-line capitalized-comments\r\n/* spell-checker: disable */\r\n'
+		input: '/* eslint-disable linebreak-style */\r\n// eslint-disable-next-line capitalized-comments\r\n/* spell-checker: disable */\r\n'
 	});
 	t.is(stdout, '');
 });
 test('eslint-disable-next-line one line input CRLF endings - no line ending disable', async t => {
 	const {stdout} = await main(['--stdin'], {
-		input: '/* eslint capitalized-comments: ["error"] */\r\n// eslint-disable-next-line capitalized-comments\r\n/* spell-checker: disable */\r\n'
+		input: '// eslint-disable-next-line capitalized-comments\r\n/* spell-checker: disable */\r\n'
 	});
 	t.is(stdout, '');
 });

--- a/test/cli-main.js
+++ b/test/cli-main.js
@@ -21,7 +21,39 @@ test('fix option with stdin', async t => {
 	});
 	t.is(stdout.trim(), 'console.log();');
 });
+test('eslint-disable-next-line exact input LF endings', async t => {
+	const {stdout} = await main(['--stdin'], {
+		input: `/* eslint capitalized-comments: ["error"] */
+// eslint-disable-next-line capitalized-comments
+/* spell-checker: disable */
 
+`
+	});
+	t.is(stdout, '');
+});
+test('eslint-disable-next-line exact input CRLF endings', async t => {
+	const {stdout} = await main(['--stdin'], {
+		input: `/* eslint-disable linebreak-style */\r
+/* eslint capitalized-comments: ["error"] */\r
+// eslint-disable-next-line capitalized-comments\r
+/* spell-checker: disable */\r
+
+`
+	});
+	t.is(stdout, '');
+});
+test('eslint-disable-next-line one line input LF endings', async t => {
+	const {stdout} = await main(['--stdin'], {
+		input: '/* eslint capitalized-comments: ["error"] */\n// eslint-disable-next-line capitalized-comments\n/* spell-checker: disable */\n'
+	});
+	t.is(stdout, '');
+});
+test('eslint-disable-next-line one line input CRLF endings', async t => {
+	const {stdout} = await main(['--stdin'], {
+		input: '/* eslint-disable linebreak-style */\r\n/* eslint capitalized-comments: ["error"] */\r\n// eslint-disable-next-line capitalized-comments\r\n/* spell-checker: disable */\r\n'
+	});
+	t.is(stdout, '');
+});
 test('stdin-filename option with stdin', async t => {
 	const {stdout} = await main(['--stdin', '--stdin-filename=unicorn-file'], {
 		input: 'console.log()\n',

--- a/test/cli-main.js
+++ b/test/cli-main.js
@@ -54,6 +54,12 @@ test('eslint-disable-next-line one line input CRLF endings', async t => {
 	});
 	t.is(stdout, '');
 });
+test('eslint-disable-next-line one line input CRLF endings - no line ending disable', async t => {
+	const {stdout} = await main(['--stdin'], {
+		input: '/* eslint capitalized-comments: ["error"] */\r\n// eslint-disable-next-line capitalized-comments\r\n/* spell-checker: disable */\r\n'
+	});
+	t.is(stdout, '');
+});
 test('stdin-filename option with stdin', async t => {
 	const {stdout} = await main(['--stdin', '--stdin-filename=unicorn-file'], {
 		input: 'console.log()\n',


### PR DESCRIPTION
Trying to reproduce an issue with disabling capitalized-comments rules.
This could not be reproduced locally in linux, but I could earlier in
the week on windows. Testing to see if this breaks in CI for the xo
plugin.

Refs eslint/eslint#12548
Refs mysticatea/eslint-plugin-eslint-comments#34