### PR TITLE
Fix Node.js range for `prefer-object-spread` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const runEslint = (paths, options) => {
 	const engine = new eslint.CLIEngine(config);
 	const report = engine.executeOnFiles(
 		paths.filter(path => !engine.isPathIgnored(path)),
-		config,
+		config
 	);
 	return processReport(report, options);
 };

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -70,7 +70,7 @@ const ENGINE_RULES = {
 		'7.6.0': 'error'
 	},
 	'prefer-object-spread': {
-		'8.0.0': 'error'
+		'8.3.0': 'error'
 	},
 	'node/prefer-global/text-decoder': {
 		'11.0.0': [


### PR DESCRIPTION
Support for object spread didn't actually land until Node.js 8.3.0

ref: https://node.green/#ES2018-features-object-rest-spread-properties-object-spread-properties