### PR TITLE
Added nodejs13 support on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - windows
 language: node_js
 node_js:
+  - '13'
   - '12'
   - '10'
   - '8'


### PR DESCRIPTION
Added travis build against Nodejs 13

Nodejs 13.0.0 has released on 10-10-2019
https://nodejs.org/en/download/releases/