### PR TITLE
Fix overrides handling for `extends`, `envs`, `globals`, `plugins`

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,6 +10,12 @@ const DEFAULT_IGNORES = [
 	'tap-snapshots/*.js'
 ];
 
+/**
+ * List of options that values will be concatenanted during option merge.
+ * Only applies to options defined as an Array.
+ */
+const MERGE_OPTIONS_CONCAT = ['extends', 'envs', 'globals', 'plugins'];
+
 const DEFAULT_EXTENSION = ['js', 'jsx'];
 
 /**
@@ -102,4 +108,12 @@ const CONFIG_FILES = [
 	`${MODULE_NAME}.config.js`
 ];
 
-module.exports = {DEFAULT_IGNORES, DEFAULT_EXTENSION, ENGINE_RULES, PRETTIER_CONFIG_OVERRIDE, MODULE_NAME, CONFIG_FILES};
+module.exports = {
+	DEFAULT_IGNORES,
+	DEFAULT_EXTENSION,
+	ENGINE_RULES,
+	PRETTIER_CONFIG_OVERRIDE,
+	MODULE_NAME,
+	CONFIG_FILES,
+	MERGE_OPTIONS_CONCAT
+};

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -12,7 +12,14 @@ const semver = require('semver');
 const {cosmiconfig, cosmiconfigSync, defaultLoaders} = require('cosmiconfig');
 const pReduce = require('p-reduce');
 const micromatch = require('micromatch');
-const {DEFAULT_IGNORES, DEFAULT_EXTENSION, ENGINE_RULES, PRETTIER_CONFIG_OVERRIDE, MODULE_NAME, CONFIG_FILES} = require('./constants');
+const {
+	DEFAULT_IGNORES,
+	DEFAULT_EXTENSION,
+	ENGINE_RULES,
+	PRETTIER_CONFIG_OVERRIDE,
+	MODULE_NAME, CONFIG_FILES,
+	MERGE_OPTIONS_CONCAT
+} = require('./constants');
 
 const DEFAULT_CONFIG = {
 	useEslintrc: false,
@@ -40,9 +47,12 @@ const getEmptyOptions = () => ({
 	extends: []
 });
 
-// Keep the same behaviour in mergeWith as deepAssign
-const mergeFn = (previousValue, value) => {
-	if (Array.isArray(previousValue) && Array.isArray(value)) {
+const mergeFn = (previousValue, value, key) => {
+	if (Array.isArray(previousValue)) {
+		if (MERGE_OPTIONS_CONCAT.includes(key)) {
+			return previousValue.concat(value);
+		}
+
 		return value;
 	}
 };
@@ -377,5 +387,6 @@ module.exports = {
 	getIgnores,
 	mergeWithFileConfigs,
 	mergeWithFileConfig,
-	buildConfig
+	buildConfig,
+	applyOverrides
 };

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -547,3 +547,38 @@ test(mergeWithFileConfigsFileType, {type: 'xo.config.js', dir: 'xo-config_js'});
 test(mergeWithFileConfigsFileType, {type: '.xo-config.js', dir: 'xo-config_js'});
 test(mergeWithFileConfigsFileType, {type: '.xo-config.json', dir: 'xo-config_json'});
 test(mergeWithFileConfigsFileType, {type: '.xo-config', dir: 'xo-config'});
+
+test('applyOverrides', t => {
+	t.deepEqual(
+		manager.applyOverrides(
+			'file.js',
+			{
+				overrides: [
+					{
+						files: 'file.js',
+						rules: {'rule-2': 'c'},
+						extends: ['overrride-extend'],
+						globals: ['override'],
+						plugins: ['override-plugin']
+					}
+				],
+				rules: {'rule-1': 'a', 'rule-2': 'b'},
+				extends: ['base-extend'],
+				globals: ['base'],
+				plugins: ['base-plugin'],
+				cwd: '.'
+			}),
+		{
+			options: {
+				rules: {'rule-1': 'a', 'rule-2': 'c'},
+				extends: ['base-extend', 'overrride-extend'],
+				globals: ['base', 'override'],
+				plugins: ['base-plugin', 'override-plugin'],
+				envs: [],
+				settings: {},
+				cwd: '.'
+			},
+			hash: 1
+		}
+	);
+});


### PR DESCRIPTION
Fix #392 

This should be a breaking change as it changes how the overrides are resolved.
The values of `extends`, `envs`, `globals` and `plugins` for overrides are are now the concatenation of the override and the global config.