### PR TITLE
Sort files path before generating unique cache key

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -184,7 +184,7 @@ Hashing based on https://github.com/eslint/eslint/blob/cf38d0d939b62f3670cdd59f0
 */
 const getTsConfigCachePath = (files, tsConfigPath) => path.join(
 	cacheLocation,
-	`tsconfig.${murmur(`${pkg.version}_${nodeVersion}_${stringify({files, tsConfigPath: tsConfigPath})}`).result().toString(36)}.json`
+	`tsconfig.${murmur(`${pkg.version}_${nodeVersion}_${stringify({files: files.sort(), tsConfigPath: tsConfigPath})}`).result().toString(36)}.json`
 );
 
 const makeTSConfig = (tsConfig, tsConfigPath, files) => {


### PR DESCRIPTION
Follow up to #431

On large project the order of files passed to the `getTsConfigCachePath` can vary from one run to the other, which result in a different tsconfig temporary file name, invalidating the ESLint cache.

This PR applies a sort to the files list to maintain a consistent file name.

Sorry about all the different PRs to finally get that functionality right...