### PR TITLE
Add `unicorn/string-content` rule

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -113,6 +113,14 @@ module.exports = {
 				}
 			}
 		],
+		'unicorn/string-content': [
+			'error',
+			{
+				patterns: {
+					[/\.\.\./.source]: '…'
+				}
+			}
+		],
 
 		// The character class sorting is a bit buggy at the moment.
 		'unicorn/better-regex': [

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"eslint-plugin-node": "^11.0.0",
 		"eslint-plugin-prettier": "^3.1.2",
 		"eslint-plugin-promise": "^4.2.1",
-		"eslint-plugin-unicorn": "^17.0.1",
+		"eslint-plugin-unicorn": "^17.2.0",
 		"find-cache-dir": "^3.0.0",
 		"fs-extra": "^8.1.0",
 		"get-stdin": "^7.0.0",


### PR DESCRIPTION
See: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/string-content.md

Anything else useful we can enforce in strings?

// @pvdlg @fregante