### PR TITLE
Add `xo-typescript` and `prettier/@typescript-eslint` before user extends

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -415,7 +415,6 @@ const mergeWithPrettierConfig = (options, prettierOptions) => {
 
 const buildTSConfig = options => config => {
 	if (options.ts) {
-		config.baseConfig.extends = config.baseConfig.extends.concat('xo-typescript');
 		config.baseConfig.parser = require.resolve('@typescript-eslint/parser');
 		config.baseConfig.parserOptions = {
 			warnOnUnsupportedTypeScriptVersion: false,
@@ -424,9 +423,12 @@ const buildTSConfig = options => config => {
 		};
 
 		if (options.prettier) {
-			config.baseConfig.extends = config.baseConfig.extends.concat('prettier/@typescript-eslint');
+			config.baseConfig.extends = ['prettier/@typescript-eslint', ...config.baseConfig.extends];
 		}
 
+		config.baseConfig.extends = ['xo-typescript', ...config.baseConfig.extends];
+
+		delete config.parser;
 		delete config.tsConfigPath;
 		delete config.ts;
 	}

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -115,11 +115,10 @@ test('buildConfig: prettier: true, typescript file', t => {
 		trailingComma: 'none'
 	}]);
 
-	// eslint-prettier-config must always be last
-	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'prettier/@typescript-eslint');
-	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 2], 'xo-typescript');
-	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 3], 'prettier/unicorn');
-	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 4], 'prettier');
+	// Config prettier/@typescript-eslint must always be after xo-typescript
+	t.deepEqual(config.baseConfig.extends[0], 'xo-typescript');
+	t.deepEqual(config.baseConfig.extends[1], 'prettier/@typescript-eslint');
+
 	// Indent rule is not enabled
 	t.is(config.rules.indent, undefined);
 	// Semi rule is not enabled
@@ -435,7 +434,7 @@ test('buildConfig: extends', t => {
 test('buildConfig: typescript', t => {
 	const config = manager.buildConfig({ts: true, tsConfigPath: './tsconfig.json'});
 
-	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'xo-typescript');
+	t.deepEqual(config.baseConfig.extends[0], 'xo-typescript');
 	t.is(config.baseConfig.parser, require.resolve('@typescript-eslint/parser'));
 	t.deepEqual(config.baseConfig.parserOptions, {
 		warnOnUnsupportedTypeScriptVersion: false,


### PR DESCRIPTION
Fix #438 

This also correctly removes the `parser` option set by the user for the Typescript files, so the option doesn't conflict with `@typescript-eslint/parser`.