### PR TITLE
Add TS extends after base XO extends and before user extends

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -259,9 +259,9 @@ Transform an XO options into ESLint compatible options:
 const buildConfig = (options, prettierOptions) =>
 	flow(
 		buildXOConfig(options),
+		buildTSConfig(options),
 		buildExtendsConfig(options),
-		buildPrettierConfig(options, prettierOptions),
-		buildTSConfig(options)
+		buildPrettierConfig(options, prettierOptions)
 	)(mergeWith(getEmptyOptions(), DEFAULT_CONFIG, normalizeOptions(options), mergeFn));
 
 const buildXOConfig = options => config => {
@@ -282,10 +282,10 @@ const buildXOConfig = options => config => {
 	}
 
 	if (options.space && !options.prettier) {
-		config.rules.indent = ['error', spaces, {SwitchCase: 1}];
-
 		if (options.ts) {
 			config.rules['@typescript-eslint/indent'] = ['error', spaces, {SwitchCase: 1}];
+		} else {
+			config.rules.indent = ['error', spaces, {SwitchCase: 1}];
 		}
 
 		// Only apply if the user has the React plugin
@@ -378,6 +378,10 @@ const buildPrettierConfig = (options, prettierConfig) => config => {
 				config.baseConfig.extends = config.baseConfig.extends.concat(prettierConfig);
 			}
 		}
+
+		if (options.ts) {
+			config.baseConfig.extends = config.baseConfig.extends.concat('prettier/@typescript-eslint');
+		}
 	}
 
 	return config;
@@ -416,6 +420,7 @@ const mergeWithPrettierConfig = (options, prettierOptions) => {
 
 const buildTSConfig = options => config => {
 	if (options.ts) {
+		config.baseConfig.extends = config.baseConfig.extends.concat('xo-typescript');
 		config.baseConfig.parser = require.resolve('@typescript-eslint/parser');
 		config.baseConfig.parserOptions = {
 			warnOnUnsupportedTypeScriptVersion: false,
@@ -427,13 +432,6 @@ const buildTSConfig = options => config => {
 					[new RegExp(`/node_modules/(?!.*\\.cache/${CACHE_DIR_NAME})`)]
 		};
 
-		if (options.prettier) {
-			config.baseConfig.extends = ['prettier/@typescript-eslint', ...config.baseConfig.extends];
-		}
-
-		config.baseConfig.extends = ['xo-typescript', ...config.baseConfig.extends];
-
-		delete config.parser;
 		delete config.tsConfigPath;
 		delete config.ts;
 	}

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -67,12 +67,6 @@ test('buildConfig: space: 4', t => {
 	t.deepEqual(config.rules.indent, ['error', 4, {SwitchCase: 1}]);
 });
 
-test('buildConfig: space: 4 (ts file)', t => {
-	const config = manager.buildConfig({space: 4, ts: true});
-	t.deepEqual(config.rules.indent, ['error', 4, {SwitchCase: 1}]);
-	t.deepEqual(config.rules['@typescript-eslint/indent'], ['error', 4, {SwitchCase: 1}]);
-});
-
 test('buildConfig: semicolon', t => {
 	const config = manager.buildConfig({semicolon: false, nodeVersion: '12'});
 	t.deepEqual(config.rules.semi, ['error', 'never']);
@@ -121,9 +115,11 @@ test('buildConfig: prettier: true, typescript file', t => {
 		trailingComma: 'none'
 	}]);
 
-	// Config prettier/@typescript-eslint must always be after xo-typescript
-	t.deepEqual(config.baseConfig.extends[0], 'xo-typescript');
-	t.deepEqual(config.baseConfig.extends[1], 'prettier/@typescript-eslint');
+	// eslint-prettier-config must always be last
+	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'prettier/@typescript-eslint');
+	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 2], 'prettier/unicorn');
+	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 3], 'prettier');
+	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 4], 'xo-typescript');
 
 	// Indent rule is not enabled
 	t.is(config.rules.indent, undefined);
@@ -440,7 +436,7 @@ test('buildConfig: extends', t => {
 test('buildConfig: typescript', t => {
 	const config = manager.buildConfig({ts: true, tsConfigPath: './tsconfig.json'});
 
-	t.deepEqual(config.baseConfig.extends[0], 'xo-typescript');
+	t.deepEqual(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'xo-typescript');
 	t.is(config.baseConfig.parser, require.resolve('@typescript-eslint/parser'));
 	t.deepEqual(config.baseConfig.parserOptions, {
 		warnOnUnsupportedTypeScriptVersion: false,


### PR DESCRIPTION
Per https://github.com/xojs/xo/pull/446#discussion_r402357614

This essentially revert #451 and #442 that weren't the correct fixes.

Instead we now add the typescript specific extends after the base XO config and before the user extends.
This allow `eslint-config-xo-typescript` to override some rules from `eslint-config-xo` and users to extend a config that override rules from both `eslint-config-xo-typescript` and `eslint-config-xo`.

@EdJoPaTo can you confirm this fix the issues reported?