### PR TITLE
Add `tap-snapshots/*.cjs` to default ignore list

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,7 +7,7 @@ const DEFAULT_IGNORES = [
 	'**/*.min.js',
 	'vendor/**',
 	'dist/**',
-	'tap-snapshots/*.js'
+	'tap-snapshots/*.{cjs,js}'
 ];
 
 /**


### PR DESCRIPTION
The next version of tap will be using the `.cjs` extension for
compatibility with packages that have `"type": "module"`.

Ref #384