### PR TITLE
Temporarily disable the `unicorn/string-content` rule

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -113,14 +113,16 @@ module.exports = {
 				}
 			}
 		],
-		'unicorn/string-content': [
-			'error',
-			{
-				patterns: {
-					[/\.\.\./.source]: '…'
-				}
-			}
-		],
+
+		// TODO: Restore when it becomes safer
+		// 'unicorn/string-content': [
+		// 	'error',
+		// 	{
+		// 		patterns: {
+		// 			[/\.\.\./.source]: '…'
+		// 		}
+		// 	}
+		// ],
 
 		// The character class sorting is a bit buggy at the moment.
 		'unicorn/better-regex': [

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -113,14 +113,6 @@ module.exports = {
 				}
 			}
 		],
-		'unicorn/string-content': [
-			'error',
-			{
-				patterns: {
-					[/\.\.\./.source]: '…'
-				}
-			}
-		],
 
 		// The character class sorting is a bit buggy at the moment.
 		'unicorn/better-regex': [

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -113,6 +113,14 @@ module.exports = {
 				}
 			}
 		],
+		'unicorn/string-content': [
+			'error',
+			{
+				patterns: {
+					[/\.\.\./.source]: '…'
+				}
+			}
+		],
 
 		// The character class sorting is a bit buggy at the moment.
 		'unicorn/better-regex': [


### PR DESCRIPTION
Not all strings are user-facing so a blanket "replace all ... with …" can break all non-tagged strings.

As reported in https://github.com/xojs/xo/pull/439#issuecomment-598751860