### PR TITLE
Enable `import/no-anonymous-default-export` and `import/no-named-default`

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -182,6 +182,7 @@ module.exports = {
 		],
 		'import/no-absolute-path': 'error',
 		'import/no-anonymous-default-export': 'error',
+		'import/no-named-default': 'error',
 		'import/no-webpack-loader-syntax': 'error',
 		'import/no-self-import': 'error',
 

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -181,6 +181,7 @@ module.exports = {
 			}
 		],
 		'import/no-absolute-path': 'error',
+		'import/no-anonymous-default-export': 'error',
 		'import/no-webpack-loader-syntax': 'error',
 		'import/no-self-import': 'error',
 


### PR DESCRIPTION
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-anonymous-default-export.md
Reports:
```js
export default () => {}
export default class {}
export default function () {}
```

Function names help automatic imports by IDEs

---

https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md

Reports: 
```js
// message: Using exported name 'bar' as identifier for default export.
import { default as foo } from './foo.js';
import { default as foo, bar } from './foo.js';
```