### PR TITLE
Add support for scoped shareable configs

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -345,6 +345,10 @@ const buildExtendsConfig = options => config => {
 				return name;
 			}
 
+			if (name.startsWith('@')) {
+				return name;
+			}
+
 			if (!name.includes('eslint-config-')) {
 				name = `eslint-config-${name}`;
 			}

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -423,13 +423,17 @@ test('buildConfig: extends', t => {
 	const config = manager.buildConfig({extends: [
 		'plugin:foo/bar',
 		'eslint-config-foo-bar',
-		'foo-bar-two'
+		'foo-bar-two',
+		'@foobar',
+		'@foobar/eslint-config'
 	]});
 
-	t.deepEqual(config.baseConfig.extends.slice(-3), [
+	t.deepEqual(config.baseConfig.extends.slice(-5), [
 		'plugin:foo/bar',
 		'cwd/eslint-config-foo-bar',
-		'cwd/eslint-config-foo-bar-two'
+		'cwd/eslint-config-foo-bar-two',
+		'@foobar',
+		'@foobar/eslint-config'
 	]);
 });
 


### PR DESCRIPTION
This pull request fixes #479 by adding a check to see if the name of the module starts with `@`. If so, it'll return the name and attempt to resolve the module as is.

I've added to the "buildConfig: extends" test for testing. I've also tested and confirmed that this works in my own project using a scoped module.

It's worth noting that eslint accepts `@scope`, `@scope/eslint-config`, and `@scope/eslint-config-my-config` with the extends option ([docs](https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules)). The goal of this PR is to allow for these cases to be used just as they can be in an eslint config.