### PR TITLE
Update to meow@7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"json-stable-stringify-without-jsonify": "^1.0.1",
 		"json5": "^2.1.3",
 		"lodash": "^4.17.15",
-		"meow": "^5.0.0",
+		"meow": "^7.0.1",
 		"micromatch": "^4.0.2",
 		"open-editor": "^2.0.1",
 		"p-reduce": "^2.1.0",


### PR DESCRIPTION
This is an attempt to update `meow` to fix #471. I welcome any advice or even concrete changes to this branch. (I'm happy to open it up to others who want to work on it.)

Here's the report from `npm test` that I'm seeing:

```
  2 tests failed
  1 known failure

  cli-main › override default ignore

  cli-main › stdin-filename option with stdin

  ~/projects/xo/test/test/cli-main.js:30

  Value must match expression:

  `␊
    <text>:1:14␊
    ✖  1:14  Missing semicolon.  semi␊
  ␊
    1 error`

  Regular expression:

  /unicorn-file:/u

  cli › runs no-local install of XO

  ~/projects/xo/test/fixtures/config-files/xo_config_js/xo.config.js:3

   2:   esnext: true
   3: }             
   4:               

  Rejected promise returned by test. Reason:

  Error {
    command: '~/projects/xo/cli.js --no-local --version',
    exitCode: 1,
    failed: true,
    isCanceled: false,
    killed: false,
    shortMessage: 'Command failed with exit code 1: ~/projects/xo/cli.js --no-local --version',
    signal: undefined,
    signalDescription: undefined,
    stderr: '',
    stdout: `<snip>`,
    timedOut: false,
    message: `Command failed with exit code 1: ~/projects/xo/cli.js --no-local --version␊
    ␊
      test/fixtures/nested/file.js:1:1␊
      ✖  1:1   Unexpected var, use let or const instead.                                      no-var␊
      ✖  1:5   The variable obj should be named object. A more descriptive name will do too.  unicorn/prevent-abbreviations␊
      ✖  1:12  There should be no space after {.                                              object-curly-spacing␊
      ✖  1:17  There should be no space before }.                                             object-curly-spacing␊
    ␊
      test/fixtures/config-files/xo-config/file.js:1:1␊
      ✖  1:1   Unexpected var, use let or const instead.                                      no-var␊
      ✖  1:5   The variable obj should be named object. A more descriptive name will do too.  unicorn/prevent-abbreviations␊
      ✖  1:12  There should be no space after {.                                              object-curly-spacing␊
      ✖  1:17  There should be no space before }.                                             object-curly-spacing␊
    ␊
      test/fixtures/config-files/xo-config_json/file.js:1:1␊
      ✖  1:1   Unexpected var, use let or const instead.                                      no-var␊
      ✖  1:5   The variable obj should be named object. A more descriptive name will do too.  unicorn/prevent-abbreviations␊
      ✖  1:12  There should be no space after {.                                              object-curly-spacing␊
      ✖  1:17  There should be no space before }.                                             object-curly-spacing␊
    ␊
      test/fixtures/config-files/xo-config_js/file.js:1:1␊
      ✖  1:1   Unexpected var, use let or const instead.                                      no-var␊
      ✖  1:5   The variable obj should be named object. A more descriptive name will do too.  unicorn/prevent-abbreviations␊
      ✖  1:12  There should be no space after {.                                              object-curly-spacing␊
      ✖  1:17  There should be no space before }.                                             object-curly-spacing␊
    ␊
      test/fixtures/config-files/xo_config_js/file.js:1:1␊
      ✖  1:1   Unexpected var, use let or const instead.                                      no-var␊
      ✖  1:5   The variable obj should be named object. A more descriptive name will do too.  unicorn/prevent-abbreviations␊
      ✖  1:12  There should be no space after {.                                              object-curly-spacing␊
      ✖  1:17  There should be no space before }.                                             object-curly-spacing␊
    ␊
      test/fixtures/typescript/child/extra-semicolon.ts:1:31␊
      ✖  1:31  Extra semicolon.                                                               @typescript-eslint/semi␊
      ✖  1:31  Missing whitespace after semicolon.                                            semi-spacing␊
      ✖  1:32  Unnecessary semicolon.                                                         @typescript-eslint/no-extra-semi␊
    ␊
      test/fixtures/engines-overrides/promise-then-transpile.js:5:10␊
      ✖  5:10  example is defined but never used.                                             no-unused-vars␊
      ✖  6:17  Prefer await to then().                                                        promise/prefer-await-to-then␊
    ␊
      test/fixtures/engines-overrides/promise-then.js:5:10␊
      ✖  5:10  example is defined but never used.                                             no-unused-vars␊
    ␊
      test/fixtures/nested-configs/no-semicolon.js:1:28␊
      ✖  1:28  Missing semicolon.                                                             semi␊
    ␊
      test/fixtures/nested-configs/child/semicolon.js:1:25␊
      ✖  1:25  Extra semicolon.                                                               semi␊
    ␊
      test/fixtures/nested-configs/child-override/two-spaces.js:2:1␊
      ✖  2:1   Expected indentation of 4 spaces but found 2.                                  indent␊
    ␊
      test/fixtures/nested-configs/child-override/child-prettier-override/semicolon.js:1:25␊
      ✖  1:25  Delete ;                                                                       prettier/prettier␊
    ␊
      test/fixtures/typescript/two-spaces.tsx:2:1␊
      ✖  2:1   Expected indentation of 4 spaces but found 2.                                  @typescript-eslint/indent␊
    ␊
      test/fixtures/typescript/child/sub-child/four-spaces.ts:2:1␊
      ✖  2:1   Expected indentation of 2 spaces but found 4.                                  @typescript-eslint/indent␊
    ␊
      test/fixtures/config-files/xo_config_js/xo.config.js:3:2␊
      ✖  3:2   Missing semicolon.                                                             semi␊
    ␊
      33 errors`,
  }

  test/fixtures/config-files/xo_config_js/xo.config.js:3:2
  at makeError (node_modules/execa/lib/error.js:59:11)
  at handlePromise (node_modules/execa/index.js:114:26)
  at test/cli.js:10:19
```