### PR TITLE
The .gitattributes cause media/logo.png to have it's line endings modified

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto eol=lf
+*.png binary
 *.ai binary


### PR DESCRIPTION
At least when I check out the repo under WSL.

