### PR TITLE
Test on Node.js 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - windows
 language: node_js
 node_js:
+  - '14'
   - '12'
   - '10'
 after_success:


### PR DESCRIPTION
Node v14 has been [current since April](https://github.com/nodejs/Release). It would be a good idea to test against the current version of node.

I understand there was an issue when v14 was first released, but it seems to have been fixed.
