### PR TITLE
Update meow from v5.0.0 to v7.0.1

### DIFF
--- a/cli-main.js
+++ b/cli-main.js
@@ -46,6 +46,7 @@ const cli = meow(`
 	  - Add XO to your project with \`npm init xo\`.
 	  - Put options in package.json instead of using flags so other tools can read it.
 `, {
+	autoVersion: false,
 	booleanDefault: undefined,
 	flags: {
 		fix: {
@@ -100,15 +101,14 @@ const cli = meow(`
 			type: 'boolean'
 		},
 		stdinFilename: {
-			type: 'string',
-			alias: 'filename'
+			type: 'string'
 		}
 	}
 });
 
 updateNotifier({pkg: cli.pkg}).notify();
 
-const {input, flags: options} = cli;
+const {input, flags: options, showVersion} = cli;
 
 // Make data types for `options.space` match those of the API
 // Check for string type because `xo --no-space` sets `options.space` to `false`
@@ -141,6 +141,10 @@ if (input[0] === '-') {
 	input.shift();
 }
 
+if (options.version) {
+	showVersion();
+}
+
 if (options.nodeVersion) {
 	if (options.nodeVersion === 'false') {
 		options.nodeVersion = false;
@@ -153,6 +157,10 @@ if (options.nodeVersion) {
 (async () => {
 	if (options.stdin) {
 		const stdin = await getStdin();
+
+		if (options.stdinFilename) {
+			options.filename = options.stdinFilename;
+		}
 
 		if (options.fix) {
 			const result = xo.lintText(stdin, options).results[0];

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"json-stable-stringify-without-jsonify": "^1.0.1",
 		"json5": "^2.1.3",
 		"lodash": "^4.17.15",
-		"meow": "^5.0.0",
+		"meow": "^7.0.1",
 		"micromatch": "^4.0.2",
 		"open-editor": "^2.0.1",
 		"p-reduce": "^2.1.0",


### PR DESCRIPTION
Two major changes were introduced in v6:

1) The `autoVersion` option does not work with 2 arguments as it was used in the test, so we disable autoVersion and implement it ourselves.

2) The `alias` option does not seem to function as we were using it so we manually copy the `stdinFilename` option to `filename` when `stdin` is enabled.

Fixes #471