### PR TITLE
Update devDependency ava from v1.1.0 to v3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 	"ava": {
 		"require": [
 			"esm"
-		]
+		],
+		"timeout": "1m"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -96,11 +96,12 @@
 		"update-notifier": "^4.1.0"
 	},
 	"devDependencies": {
-		"ava": "^1.1.0",
+		"ava": "^3.9.0",
 		"coveralls": "^3.1.0",
 		"eslint-config-xo-react": "^0.23.0",
 		"eslint-plugin-react": "^7.20.0",
 		"eslint-plugin-react-hooks": "^4.0.4",
+		"esm": "^3.2.25",
 		"execa": "^4.0.2",
 		"nyc": "^15.1.0",
 		"pify": "^5.0.0",
@@ -113,5 +114,10 @@
 	},
 	"eslintIgnore": [
 		"test/fixtures"
-	]
+	],
+	"ava": {
+		"require": [
+			"esm"
+		]
+	}
 }

--- a/test/lint-text.js
+++ b/test/lint-text.js
@@ -74,7 +74,7 @@ test('`ignores` option without filename', t => {
 		fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
 			ignores: ['ignored/**/*.js']
 		});
-	}, /The `ignores` option requires the `filename` option to be defined./u);
+	}, {message: /The `ignores` option requires the `filename` option to be defined./u});
 });
 
 test('JSX support', t => {
@@ -140,22 +140,22 @@ test('regression test for #71', t => {
 	const {results} = fn.lintText('const foo = { key: \'value\' };\nconsole.log(foo);\n', {
 		extends: path.join(__dirname, 'fixtures/extends.js')
 	});
-	t.is(results[0].errorCount, 0, results[0]);
+	t.is(results[0].errorCount, 0);
 });
 
 test('lintText() - overrides support', async t => {
 	const cwd = path.join(__dirname, 'fixtures/overrides');
 	const bar = path.join(cwd, 'test/bar.js');
 	const barResults = fn.lintText(await readFile(bar, 'utf8'), {filename: bar, cwd}).results;
-	t.is(barResults[0].errorCount, 0, barResults[0]);
+	t.is(barResults[0].errorCount, 0);
 
 	const foo = path.join(cwd, 'test/foo.js');
 	const fooResults = fn.lintText(await readFile(foo, 'utf8'), {filename: foo, cwd}).results;
-	t.is(fooResults[0].errorCount, 0, fooResults[0]);
+	t.is(fooResults[0].errorCount, 0);
 
 	const index = path.join(cwd, 'test/index.js');
 	const indexResults = fn.lintText(await readFile(bar, 'utf8'), {filename: index, cwd}).results;
-	t.is(indexResults[0].errorCount, 0, indexResults[0]);
+	t.is(indexResults[0].errorCount, 0);
 });
 
 test('do not lint gitignored files if filename is given', async t => {


### PR DESCRIPTION
There were 3 changes required to update the `ava` devDependency from `v1.1.0` to `v3.9.0`:

1) `ava` no longer automatically supports ESM syntax. We need to add `esm` to `devDependencies` and add some configuration to instruct `ava` to use the `esm` library.

2) The acceptable arguments for messages has been restricted to strings. In a two different tests the results object was used as the message. Removing the message matches the usage in the majority of tests.

3) The signature for the expectation argument in throws has changed and now requires an object. In one case a regex was used. Moving the regex into the `message` property on resolved the issue.

