### PR TITLE
Respect Prettier’s use of .editorconfig

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -133,8 +133,7 @@ const mergeWithFileConfigs = async (files, options, configFiles) => {
 		const {hash, options: optionsWithOverrides} = applyOverrides(file, fileOptions);
 		fileOptions = optionsWithOverrides;
 
-		const prettierConfigPath = fileOptions.prettier ? await prettier.resolveConfigFile(file) : undefined;
-		const prettierOptions = prettierConfigPath ? await prettier.resolveConfig(file, {config: prettierConfigPath}) : {};
+		const prettierOptions = fileOptions.prettier ? await prettier.resolveConfig(file) || {} : {};
 
 		let tsConfigPath;
 		if (isTypescript(file)) {
@@ -147,7 +146,7 @@ const mergeWithFileConfigs = async (files, options, configFiles) => {
 			fileOptions.ts = true;
 		}
 
-		const cacheKey = stringify({xoConfigPath, enginesConfigPath, prettierConfigPath, hash, tsConfigPath: fileOptions.tsConfigPath, ts: fileOptions.ts});
+		const cacheKey = stringify({xoConfigPath, enginesConfigPath, prettierOptions, hash, tsConfigPath: fileOptions.tsConfigPath, ts: fileOptions.ts});
 		const cachedGroup = configs.get(cacheKey);
 
 		configs.set(cacheKey, {

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -99,7 +99,7 @@ const mergeWithFileConfig = options => {
 		({options} = applyOverrides(options.filename, options));
 	}
 
-	const prettierOptions = options.prettier ? prettier.resolveConfig.sync(searchPath) || {} : {};
+	const prettierOptions = options.prettier ? prettier.resolveConfig.sync(searchPath, {editorconfig: true}) || {} : {};
 
 	if (options.filename && isTypescript(options.filename)) {
 		const tsConfigExplorer = cosmiconfigSync([], {searchPlaces: ['tsconfig.json'], loaders: {'.json': (_, content) => JSON5.parse(content)}});
@@ -133,7 +133,7 @@ const mergeWithFileConfigs = async (files, options, configFiles) => {
 		const {hash, options: optionsWithOverrides} = applyOverrides(file, fileOptions);
 		fileOptions = optionsWithOverrides;
 
-		const prettierOptions = fileOptions.prettier ? await prettier.resolveConfig(file) || {} : {};
+		const prettierOptions = fileOptions.prettier ? await prettier.resolveConfig(file, {editorconfig: true}) || {} : {};
 
 		let tsConfigPath;
 		if (isTypescript(file)) {

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -638,7 +638,7 @@ test('mergeWithFileConfigs: nested configs with prettier', async t => {
 				extensions: DEFAULT_EXTENSION,
 				ignores: DEFAULT_IGNORES
 			},
-			prettierOptions: {semi: false}
+			prettierOptions: {endOfLine: 'lf', semi: false, useTabs: true}
 		}
 	]);
 });


### PR DESCRIPTION
The `prettier` CLI by [default](https://prettier.io/docs/en/cli.html#--no-editorconfig) reads [certain options](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options) from `.editorconfig` if they are present. We should respect them too under `"prettier": true`. This is a simple matter of passing the appropriate flag to `prettier.resolveConfig`.