### PR TITLE
Enable automatic annotations on GitHub Actions

### DIFF
--- a/cli-main.js
+++ b/cli-main.js
@@ -4,6 +4,7 @@ const updateNotifier = require('update-notifier');
 const getStdin = require('get-stdin');
 const meow = require('meow');
 const formatterPretty = require('eslint-formatter-pretty');
+const formatterCompact = require('eslint/lib/cli-engine/formatters/compact');
 const semver = require('semver');
 const openReport = require('./lib/open-report');
 const xo = require('.');
@@ -136,7 +137,7 @@ if (typeof options.space === 'string') {
 }
 
 const log = report => {
-	const reporter = options.reporter ? xo.getFormatter(options.reporter) : formatterPretty;
+	const reporter = options.reporter ? xo.getFormatter(options.reporter) : process.env.GITHUB_ACTIONS ? formatterCompact : formatterPretty;
 	process.stdout.write(reporter(report.results));
 	process.exitCode = report.errorCount === 0 ? 0 : 1;
 };

--- a/cli-main.js
+++ b/cli-main.js
@@ -4,7 +4,6 @@ const updateNotifier = require('update-notifier');
 const getStdin = require('get-stdin');
 const meow = require('meow');
 const formatterPretty = require('eslint-formatter-pretty');
-const formatterCompact = require('eslint/lib/cli-engine/formatters/compact');
 const semver = require('semver');
 const openReport = require('./lib/open-report');
 const xo = require('.');
@@ -137,7 +136,7 @@ if (typeof options.space === 'string') {
 }
 
 const log = report => {
-	const reporter = options.reporter ? xo.getFormatter(options.reporter) : process.env.GITHUB_ACTIONS ? formatterCompact : formatterPretty;
+	const reporter = options.reporter || process.env.GITHUB_ACTIONS ? xo.getFormatter(options.reporter || 'compact') : formatterPretty;
 	process.stdout.write(reporter(report.results));
 	process.exitCode = report.errorCount === 0 ? 0 : 1;
 };


### PR DESCRIPTION
Closes #465 

I tested locally and the logic seems correct:

```
❯ xo

  index.js:10:15
  ✖  10:15  Multiple spaces found before =.  no-multi-spaces
  ✖  11:41  Missing semicolon.               semi

  2 errors

❯ export GITHUB_ACTIONS=true
❯ xo
./index.js: line 10, col 15, Error - Multiple spaces found before '='. (no-multi-spaces)
./index.js: line 11, col 41, Error - Missing semicolon. (semi)

2 problems⏎
```

However I don't know if this actually works on GHA. The syntax that appears on GHA (as shown in #465) is not this one.