### PR TITLE
Bump Prettier to ^2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"open-editor": "^2.0.1",
 		"p-reduce": "^2.1.0",
 		"path-exists": "^4.0.0",
-		"prettier": "2.0.4",
+		"prettier": "^2.1.2",
 		"resolve-cwd": "^3.0.0",
 		"resolve-from": "^5.0.0",
 		"semver": "^7.3.2",


### PR DESCRIPTION
Closes #500

After using the Yarn resolutions method in the linked issue for a while, I haven't noticed anything breaking by upgrading Prettier.
This will bring TypeScript v4 support to Prettier.

As a note, this doesn't fix #466 but it seems somebody has found the cause and outlined some possible solutions in this comment: https://github.com/xojs/xo/issues/483#issuecomment-722618023