### PR TITLE
Fix ignored package.json config when using the CLI

### DIFF
--- a/cli-main.js
+++ b/cli-main.js
@@ -116,8 +116,9 @@ updateNotifier({pkg: cli.pkg}).notify();
 
 const {input, flags: options, showVersion} = cli;
 
-// Revert behavior of meow >8 to pre-8 (7.1.1) for flags using `isMultiple: true``
-// Otherwise options defined in package.json can't be merged by lib/options-manager.js mergeOptions()
+// TODO: Fix this properly instead of the below workaround.
+// Revert behavior of meow >8 to pre-8 (7.1.1) for flags using `isMultiple: true`.
+// Otherwise, options defined in package.json can't be merged by lib/options-manager.js `mergeOptions()`.
 for (const key in options) {
 	if (Array.isArray(options[key]) && options[key].length === 0) {
 		delete options[key];

--- a/cli-main.js
+++ b/cli-main.js
@@ -116,6 +116,14 @@ updateNotifier({pkg: cli.pkg}).notify();
 
 const {input, flags: options, showVersion} = cli;
 
+// Revert behavior of meow >8 to pre-8 (7.1.1) for flags using `isMultiple: true``
+// Otherwise options defined in package.json can't be merged by lib/options-manager.js mergeOptions()
+for (const key in options) {
+	if (Array.isArray(options[key]) && options[key].length === 0) {
+		delete options[key];
+	}
+}
+
 // Make data types for `options.space` match those of the API
 // Check for string type because `xo --no-space` sets `options.space` to `false`
 if (typeof options.space === 'string') {


### PR DESCRIPTION
### Reproduce
https://github.com/dersimn/issue-xo

`package.json`:

```json
{
  "devDependencies": {
    "xo": "^0.36.1"
  },
  "xo": {
    "space": 4,
    "globals": [
      "myGlobalFunction"
    ]
  }
}

```

`index.js`:

```javascript
function something(foo) {
    myGlobalFunction(foo);
}

something();

```

1) `npx xo`
    - Runs without errors
2) `cat index.js | npx xo --stdin`: 
    - Returns: `✖  2:5  myGlobalFunction is not defined.  no-undef`
    - However the `space: 4` option is respected.
    - `cat index.js | npx xo --globals myGlobalFunction --stdin` works
    - Maybe because `rules` are simply forwarded to eslint and all other options are parsed by XO ?

This issue occurred first on update from [`v0.34.2` to `v0.35.0`](https://github.com/xojs/xo/compare/v0.34.2...v0.35.0). 


### Fix

The issue seems to be the update from `"meow": "^7.1.1"` to `"meow": "^8.0.0"`.  

To verify place `console.log('foo', options);` before [line 61 in index.js](https://github.com/xojs/xo/blob/33b769ec71498f4c788fe01e17c043908ad0205d/index.js#L61) and call `cat index.js | npx xo --stdin`:

With xo `v0.34.2` (using meow `v7.1.1`) this debug line outputs:
```
foo { stdin: true }
```

With xo `v0.35.0` (using meow `v8.0.0`) this debug line outputs:
```
foo {
  stdin: true,
  env: [],
  global: [],
  ignore: [],
  plugin: [],
  extend: [],
  extension: []
}
```

This is because the behavior of meow's `isMultiple ` (used for e.g. [here](https://github.com/xojs/xo/blob/33b769ec71498f4c788fe01e17c043908ad0205d/cli-main.js#L64)) changed when fixing sindresorhus/meow#161, however XO can't deal with this yet when merging CLI options with options from `package.json`.

Trace of calls:

- [cli-main.js#187 **calling** lintText()](https://github.com/xojs/xo/blob/8156d42ce879c32edc231714c2e6e3eaa0092f70/cli-main.js#L187)
- [index.js#60 lintText()](https://github.com/xojs/xo/blob/8156d42ce879c32edc231714c2e6e3eaa0092f70/index.js#L60)
- [index.js#61 lintText() **calling** mergeWithFileConfig()](https://github.com/xojs/xo/blob/8156d42ce879c32edc231714c2e6e3eaa0092f70/index.js#L61)
- [lib/options-manager.js#82 mergeWithFileConfig()](https://github.com/xojs/xo/blob/8156d42ce879c32edc231714c2e6e3eaa0092f70/lib/options-manager.js#L82)
- [lib/options-manager.js#95 mergeWithFileConfig() **calling** mergeOptions()](https://github.com/xojs/xo/blob/8156d42ce879c32edc231714c2e6e3eaa0092f70/lib/options-manager.js#L95)
- [lib/options-manager.js#239 mergeOptions()](https://github.com/xojs/xo/blob/8156d42ce879c32edc231714c2e6e3eaa0092f70/lib/options-manager.js#L239)
- [lib/options-manager.js#243 mergeOptions() using Spread operator](https://github.com/xojs/xo/blob/8156d42ce879c32edc231714c2e6e3eaa0092f70/lib/options-manager.js#243) and overwriting full array from `package.json` with empty array from meow-CLI


### Fixes:

Fixes xojs/xo#509
Fixes xojs/SublimeLinter-contrib-xo#17

