### PR TITLE
Disable the `node/file-extension-in-import` rule for TypeScript projects

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -317,6 +317,7 @@ const buildXOConfig = options => config => {
 
 	if (options.ts) {
 		config.rules['unicorn/import-style'] = 'off';
+		config.rules['node/file-extension-in-import'] = 'off';
 	}
 
 	if (options.rules) {


### PR DESCRIPTION
Closes #522