### PR TITLE
Mention in project description that XO is an ESLint wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "xo",
 	"version": "0.38.2",
-	"description": "JavaScript/TypeScript linter with great defaults",
+	"description": "JavaScript/TypeScript linter (ESLint wrapper) with great defaults",
 	"license": "MIT",
 	"repository": "xojs/xo",
 	"funding": "https://github.com/sponsors/sindresorhus",

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 	<br>
 </h1>
 
-> JavaScript/TypeScript linter with great defaults
+> JavaScript/TypeScript linter (ESLint wrapper) with great defaults
 
 [![Coverage Status](https://codecov.io/gh/xojs/xo/branch/main/graph/badge.svg)](https://codecov.io/gh/xojs/xo/branch/main)
 [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo)


### PR DESCRIPTION
With this PR I change the description in `readme.md`(1st phrase) and in `package.json`, from:
`JavaScript/TypeScript linter with great defaults` to:
`JavaScript/TypeScript linter (ESLint wrapper) with great defaults`
in order to better clarify/stand out that xo uses ESLint underneath, an already very popular and widely used JavaScript linter,
and that it's not a linter itself, like JSLint, JSHint, ESLint, etc,
something that might discourage a new user from trying it, if he sees it for the first time, and has never heard of it.

Currently, searching in GitHub and npmjs, 
the description, as it is, and the tags used in npmjs, 
might all give the wrong impression that it's the opposite:

screenshots:
<details>
<summary>GitHub search</summary>

![2021-04-02_155655](https://user-images.githubusercontent.com/723651/113417984-3d3e3d80-93cd-11eb-84bd-aaf123dc1da0.jpg)
</details>

<details>
<summary>npmjs dropdown</summary>

![2021-04-02_160311](https://user-images.githubusercontent.com/723651/113418002-47603c00-93cd-11eb-94f7-8ea70c0b27be.jpg)
</details>

<details>
<summary>npmjs search</summary>

![2021-04-02_155952](https://user-images.githubusercontent.com/723651/113417992-4202f180-93cd-11eb-83c8-c865dee573c2.jpg)
</details>

&nbsp;
Thank you