### PR TITLE
Add `--print-config` flag

### DIFF
--- a/cli-main.js
+++ b/cli-main.js
@@ -164,7 +164,7 @@ if (options.nodeVersion) {
 	if (options.nodeVersion === 'false') {
 		options.nodeVersion = false;
 	} else if (!semver.validRange(options.nodeVersion)) {
-		console.error('The `node-engine` option must be a valid semver range (for example `>=6`)');
+		console.error('The `--node-engine` flag must be a valid semver range (for example `>=6`)');
 		process.exit(1);
 	}
 }
@@ -185,7 +185,7 @@ if (options.nodeVersion) {
 		}
 
 		if (options.open) {
-			console.error('The `open` option is not supported on stdin');
+			console.error('The `--open` flag is not supported on stdin');
 			process.exit(1);
 		}
 

--- a/cli-main.js
+++ b/cli-main.js
@@ -30,6 +30,7 @@ const cli = meow(`
 	  --cwd=<dir>       Working directory for files
 	  --stdin           Validate/fix code from stdin
 	  --stdin-filename  Specify a filename for the --stdin option
+	  --print-config    Print the effective ESLint config for the given file
 
 	Examples
 	  $ xo
@@ -40,6 +41,7 @@ const cli = meow(`
 	  $ xo --plugin=react
 	  $ xo --plugin=html --extension=html
 	  $ echo 'const x=true' | xo --stdin --fix
+	  $ xo --print-config=index.js
 
 	Tips
 	  - Add XO to your project with \`npm init xo\`.
@@ -97,6 +99,9 @@ const cli = meow(`
 			isMultiple: true
 		},
 		cwd: {
+			type: 'string'
+		},
+		printConfig: {
 			type: 'string'
 		},
 		stdin: {
@@ -170,7 +175,21 @@ if (options.nodeVersion) {
 }
 
 (async () => {
-	if (options.stdin) {
+	if (options.printConfig) {
+		if (input.length > 0) {
+			console.error('The `--print-config` flag must be used with exactly one filename');
+			process.exit(1);
+		}
+
+		if (options.stdin) {
+			console.error('The `--print-config` flag is not supported on stdin');
+			process.exit(1);
+		}
+
+		options.filename = options.printConfig;
+		const config = xo.getConfig(options);
+		console.log(JSON.stringify(config, undefined, '\t'));
+	} else if (options.stdin) {
 		const stdin = await getStdin();
 
 		if (options.stdinFilename) {

--- a/index.js
+++ b/index.js
@@ -57,6 +57,13 @@ const globFiles = async (patterns, {ignores, extensions, cwd}) => (
 		{ignore: ignores, gitignore: true, cwd}
 	)).filter(file => extensions.includes(path.extname(file).slice(1))).map(file => path.resolve(cwd, file));
 
+const getConfig = options => {
+	const {options: foundOptions, prettierOptions} = mergeWithFileConfig(normalizeOptions(options));
+	options = buildConfig(foundOptions, prettierOptions);
+	const engine = new eslint.CLIEngine(options);
+	return engine.getConfigForFile(options.filename);
+};
+
 const lintText = (string, options) => {
 	const {options: foundOptions, prettierOptions} = mergeWithFileConfig(normalizeOptions(options));
 	options = buildConfig(foundOptions, prettierOptions);
@@ -121,6 +128,7 @@ module.exports = {
 	getFormatter: eslint.CLIEngine.getFormatter,
 	getErrorResults: eslint.CLIEngine.getErrorResults,
 	outputFixes: eslint.CLIEngine.outputFixes,
+	getConfig,
 	lintText,
 	lintFiles
 };

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ $ xo --help
     --cwd=<dir>       Working directory for files
     --stdin           Validate/fix code from stdin
     --stdin-filename  Specify a filename for the --stdin option
+    --print-config    Print the ESLint configuration for the given file
 
   Examples
     $ xo
@@ -81,6 +82,7 @@ $ xo --help
     $ xo --plugin=react
     $ xo --plugin=html --extension=html
     $ echo 'const x=true' | xo --stdin --fix
+    $ xo --print-config=index.js
 
   Tips
     - Add XO to your project with `npm init xo`.

--- a/test/cli-main.js
+++ b/test/cli-main.js
@@ -166,3 +166,17 @@ test('extension option', async t => {
 	t.is(reports.length, 1);
 	t.true(reports[0].filePath.endsWith('.unknown'));
 });
+
+test('invalid print-config flag with stdin', async t => {
+	const error = await t.throwsAsync(() =>
+		main(['--print-config', 'x.js', '--stdin'], {input: 'console.log()\n'})
+	);
+	t.is(error.stderr.trim(), 'The `--print-config` flag is not supported on stdin');
+});
+
+test('print-config flag requires a single filename', async t => {
+	const error = await t.throwsAsync(() =>
+		main(['--print-config', 'x.js', 'y.js'])
+	);
+	t.is(error.stderr.trim(), 'The `--print-config` flag must be used with exactly one filename');
+});

--- a/test/cli-main.js
+++ b/test/cli-main.js
@@ -33,11 +33,10 @@ test('stdin-filename option with stdin', async t => {
 test('reporter option', async t => {
 	const filepath = await tempWrite('console.log()\n', 'x.js');
 
-	try {
-		await main(['--reporter=compact', filepath]);
-	} catch (error) {
-		t.true(error.stdout.includes('Error - '));
-	}
+	const error = await t.throwsAsync(() =>
+		main(['--reporter=compact', filepath])
+	);
+	t.true(error.stdout.includes('Error - '));
 });
 
 test('overrides fixture', async t => {

--- a/test/lint-files.js
+++ b/test/lint-files.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import test from 'ava';
-import fn from '..';
+import xo from '..';
 
 process.chdir(__dirname);
 
@@ -14,18 +14,18 @@ test('only accepts allowed extensions', async t => {
 	const mdGlob = path.join(__dirname, '..', '*.md');
 
 	// No files should be linted = no errors
-	const noOptionsResults = await fn.lintFiles(mdGlob, {});
+	const noOptionsResults = await xo.lintFiles(mdGlob, {});
 	t.is(noOptionsResults.errorCount, 0);
 
 	// Markdown files linted (with no plugin for it) = errors
-	const moreExtensionsResults = await fn.lintFiles(mdGlob, {extensions: ['md']});
+	const moreExtensionsResults = await xo.lintFiles(mdGlob, {extensions: ['md']});
 	t.true(moreExtensionsResults.errorCount > 0);
 });
 
 test('ignores dirs for empty extensions', async t => {
 	{
 		const glob = path.join(__dirname, 'fixtures/nodir/*');
-		const results = await fn.lintFiles(glob, {extensions: ['', 'js']});
+		const results = await xo.lintFiles(glob, {extensions: ['', 'js']});
 		const {results: [fileResult]} = results;
 
 		// Only `fixtures/nodir/noextension` should be linted
@@ -37,7 +37,7 @@ test('ignores dirs for empty extensions', async t => {
 
 	{
 		const glob = path.join(__dirname, 'fixtures/nodir/nested/*');
-		const results = await fn.lintFiles(glob);
+		const results = await xo.lintFiles(glob);
 		const {results: [fileResult]} = results;
 
 		// Ensure `nodir/nested` **would** report if globbed
@@ -49,7 +49,7 @@ test('ignores dirs for empty extensions', async t => {
 });
 
 test.serial('cwd option', async t => {
-	const {results} = await fn.lintFiles('**/*', {cwd: 'fixtures/cwd'});
+	const {results} = await xo.lintFiles('**/*', {cwd: 'fixtures/cwd'});
 	const paths = results.map(r => path.relative(__dirname, r.filePath));
 	paths.sort();
 	t.deepEqual(paths, [path.join('fixtures', 'cwd', 'unicorn.js')]);
@@ -59,7 +59,7 @@ test('do not lint gitignored files', async t => {
 	const cwd = path.join(__dirname, 'fixtures/gitignore');
 	const glob = path.posix.join(cwd, '**/*');
 	const ignored = path.resolve('fixtures/gitignore/test/foo.js');
-	const {results} = await fn.lintFiles(glob, {cwd});
+	const {results} = await xo.lintFiles(glob, {cwd});
 
 	t.is(results.some(r => r.filePath === ignored), false);
 });
@@ -68,7 +68,7 @@ test('do not lint gitignored files in file with negative gitignores', async t =>
 	const cwd = path.join(__dirname, 'fixtures/negative-gitignore');
 	const glob = path.posix.join(cwd, '*');
 	const ignored = path.resolve('fixtures/negative-gitignore/bar.js');
-	const {results} = await fn.lintFiles(glob, {cwd});
+	const {results} = await xo.lintFiles(glob, {cwd});
 
 	t.is(results.some(r => r.filePath === ignored), false);
 });
@@ -77,7 +77,7 @@ test('lint negatively gitignored files', async t => {
 	const cwd = path.join(__dirname, 'fixtures/negative-gitignore');
 	const glob = path.posix.join(cwd, '*');
 	const negative = path.resolve('fixtures/negative-gitignore/foo.js');
-	const {results} = await fn.lintFiles(glob, {cwd});
+	const {results} = await xo.lintFiles(glob, {cwd});
 
 	t.is(results.some(r => r.filePath === negative), true);
 });
@@ -86,14 +86,14 @@ test('do not lint inapplicable negatively gitignored files', async t => {
 	const cwd = path.join(__dirname, 'fixtures/negative-gitignore');
 	const glob = path.posix.join(cwd, 'bar.js');
 	const negative = path.resolve('fixtures/negative-gitignore/foo.js');
-	const {results} = await fn.lintFiles(glob, {cwd});
+	const {results} = await xo.lintFiles(glob, {cwd});
 
 	t.is(results.some(r => r.filePath === negative), false);
 });
 
 test('multiple negative patterns should act as positive patterns', async t => {
 	const cwd = path.join(__dirname, 'fixtures', 'gitignore-multiple-negation');
-	const {results} = await fn.lintFiles('**/*', {cwd});
+	const {results} = await xo.lintFiles('**/*', {cwd});
 	const paths = results.map(r => path.basename(r.filePath));
 	paths.sort();
 
@@ -101,7 +101,7 @@ test('multiple negative patterns should act as positive patterns', async t => {
 });
 
 test('enable rules based on nodeVersion', async t => {
-	const {results} = await fn.lintFiles('**/*', {cwd: 'fixtures/engines-overrides'});
+	const {results} = await xo.lintFiles('**/*', {cwd: 'fixtures/engines-overrides'});
 
 	// The transpiled file (as specified in `overrides`) should use `await`
 	t.true(
@@ -126,14 +126,14 @@ test('do not lint eslintignored files', async t => {
 	const glob = path.posix.join(cwd, '*');
 	const positive = path.resolve('fixtures/eslintignore/foo.js');
 	const negative = path.resolve('fixtures/eslintignore/bar.js');
-	const {results} = await fn.lintFiles(glob, {cwd});
+	const {results} = await xo.lintFiles(glob, {cwd});
 
 	t.is(results.some(r => r.filePath === positive), true);
 	t.is(results.some(r => r.filePath === negative), false);
 });
 
 test('find configurations close to linted file', async t => {
-	const {results} = await fn.lintFiles('**/*', {cwd: 'fixtures/nested-configs'});
+	const {results} = await xo.lintFiles('**/*', {cwd: 'fixtures/nested-configs'});
 
 	t.true(
 		hasRule(
@@ -169,7 +169,7 @@ test('find configurations close to linted file', async t => {
 });
 
 test('typescript files', async t => {
-	const {results} = await fn.lintFiles('**/*', {cwd: 'fixtures/typescript'});
+	const {results} = await xo.lintFiles('**/*', {cwd: 'fixtures/typescript'});
 
 	t.true(
 		hasRule(
@@ -197,23 +197,23 @@ test('typescript files', async t => {
 });
 
 test('typescript 2 space option', async t => {
-	const {errorCount, results} = await fn.lintFiles('two-spaces.tsx', {cwd: 'fixtures/typescript', space: 2});
+	const {errorCount, results} = await xo.lintFiles('two-spaces.tsx', {cwd: 'fixtures/typescript', space: 2});
 	t.is(errorCount, 0, JSON.stringify(results[0].messages));
 });
 
 test('typescript 4 space option', async t => {
-	const {errorCount} = await fn.lintFiles('child/sub-child/four-spaces.ts', {cwd: 'fixtures/typescript', space: 4});
+	const {errorCount} = await xo.lintFiles('child/sub-child/four-spaces.ts', {cwd: 'fixtures/typescript', space: 4});
 	t.is(errorCount, 0);
 });
 
 test('typescript no semicolon option', async t => {
-	const {errorCount} = await fn.lintFiles('child/no-semicolon.ts', {cwd: 'fixtures/typescript', semicolon: false});
+	const {errorCount} = await xo.lintFiles('child/no-semicolon.ts', {cwd: 'fixtures/typescript', semicolon: false});
 	t.is(errorCount, 0);
 });
 
 test('webpack import resolver is used if webpack.config.js is found', async t => {
 	const cwd = 'fixtures/webpack/with-config/';
-	const {results} = await fn.lintFiles(path.resolve(cwd, 'file1.js'), {
+	const {results} = await xo.lintFiles(path.resolve(cwd, 'file1.js'), {
 		cwd,
 		rules: {
 			'import/no-unresolved': 2
@@ -229,7 +229,7 @@ test('webpack import resolver is used if webpack.config.js is found', async t =>
 test('webpack import resolver config can be passed through webpack option', async t => {
 	const cwd = 'fixtures/webpack/no-config/';
 
-	const {results} = await fn.lintFiles(path.resolve(cwd, 'file1.js'), {
+	const {results} = await xo.lintFiles(path.resolve(cwd, 'file1.js'), {
 		cwd,
 		webpack: {
 			config: {
@@ -251,7 +251,7 @@ test('webpack import resolver config can be passed through webpack option', asyn
 test('webpack import resolver is used if {webpack: true}', async t => {
 	const cwd = 'fixtures/webpack/no-config/';
 
-	const {results} = await fn.lintFiles(path.resolve(cwd, 'file3.js'), {
+	const {results} = await xo.lintFiles(path.resolve(cwd, 'file3.js'), {
 		cwd,
 		webpack: true,
 		rules: {
@@ -264,7 +264,7 @@ test('webpack import resolver is used if {webpack: true}', async t => {
 });
 
 async function configType(t, {dir}) {
-	const {results} = await fn.lintFiles('**/*', {cwd: path.resolve('fixtures', 'config-files', dir)});
+	const {results} = await xo.lintFiles('**/*', {cwd: path.resolve('fixtures', 'config-files', dir)});
 
 	t.true(
 		hasRule(

--- a/test/lint-text.js
+++ b/test/lint-text.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import test from 'ava';
 import pify from 'pify';
-import fn from '..';
+import xo from '..';
 
 process.chdir(__dirname);
 
@@ -10,12 +10,12 @@ const readFile = pify(fs.readFile);
 const hasRule = (results, ruleId) => results[0].messages.some(x => x.ruleId === ruleId);
 
 test('.lintText()', t => {
-	const {results} = fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n');
+	const {results} = xo.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n');
 	t.true(hasRule(results, 'semi'));
 });
 
 test('default `ignores`', t => {
-	const result = fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
+	const result = xo.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
 		filename: 'node_modules/ignored/index.js'
 	});
 	t.is(result.errorCount, 0);
@@ -23,7 +23,7 @@ test('default `ignores`', t => {
 });
 
 test('`ignores` option', t => {
-	const result = fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
+	const result = xo.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
 		filename: 'ignored/index.js',
 		ignores: ['ignored/**/*.js']
 	});
@@ -32,7 +32,7 @@ test('`ignores` option', t => {
 });
 
 test('`ignores` option without cwd', t => {
-	const result = fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
+	const result = xo.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
 		filename: 'ignored/index.js',
 		ignores: ['ignored/**/*.js']
 	});
@@ -41,7 +41,7 @@ test('`ignores` option without cwd', t => {
 });
 
 test('respect overrides', t => {
-	const result = fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
+	const result = xo.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
 		filename: 'ignored/index.js',
 		ignores: ['ignored/**/*.js'],
 		overrides: [
@@ -56,7 +56,7 @@ test('respect overrides', t => {
 });
 
 test('overriden ignore', t => {
-	const result = fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
+	const result = xo.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
 		filename: 'unignored.js',
 		overrides: [
 			{
@@ -71,19 +71,19 @@ test('overriden ignore', t => {
 
 test('`ignores` option without filename', t => {
 	t.throws(() => {
-		fn.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
+		xo.lintText('\'use strict\'\nconsole.log(\'unicorn\');\n', {
 			ignores: ['ignored/**/*.js']
 		});
 	}, {message: /The `ignores` option requires the `filename` option to be defined./u});
 });
 
 test('JSX support', t => {
-	const {results} = fn.lintText('const app = <div className="appClass">Hello, React!</div>;\n');
+	const {results} = xo.lintText('const app = <div className="appClass">Hello, React!</div>;\n');
 	t.true(hasRule(results, 'no-unused-vars'));
 });
 
 test('plugin support', t => {
-	const {results} = fn.lintText('var React;\nReact.render(<App/>);\n', {
+	const {results} = xo.lintText('var React;\nReact.render(<App/>);\n', {
 		plugins: ['react'],
 		rules: {'react/jsx-no-undef': 'error'}
 	});
@@ -91,25 +91,25 @@ test('plugin support', t => {
 });
 
 test('prevent use of extended native objects', t => {
-	const {results} = fn.lintText('[].unicorn();\n');
+	const {results} = xo.lintText('[].unicorn();\n');
 	t.true(hasRule(results, 'no-use-extend-native/no-use-extend-native'));
 });
 
 test('extends support', t => {
-	const {results} = fn.lintText('var React;\nReact.render(<App/>);\n', {
+	const {results} = xo.lintText('var React;\nReact.render(<App/>);\n', {
 		extends: 'xo-react'
 	});
 	t.true(hasRule(results, 'react/jsx-no-undef'));
 });
 
 test('disable style rules when `prettier` option is enabled', t => {
-	const withoutPrettier = fn.lintText('(a) => {}\n', {filename: 'test.js'}).results;
+	const withoutPrettier = xo.lintText('(a) => {}\n', {filename: 'test.js'}).results;
 	// `arrow-parens` is enabled
 	t.true(hasRule(withoutPrettier, 'arrow-parens'));
 	// `prettier/prettier` is disabled
 	t.false(hasRule(withoutPrettier, 'prettier/prettier'));
 
-	const withPrettier = fn.lintText('(a) => {}\n', {prettier: true, filename: 'test.js'}).results;
+	const withPrettier = xo.lintText('(a) => {}\n', {prettier: true, filename: 'test.js'}).results;
 	// `arrow-parens` is disabled by `eslint-config-prettier`
 	t.false(hasRule(withPrettier, 'arrow-parens'));
 	// `prettier/prettier` is enabled
@@ -117,7 +117,7 @@ test('disable style rules when `prettier` option is enabled', t => {
 });
 
 test('extends `react` support with `prettier` option', t => {
-	const {results} = fn.lintText('<Hello name={ firstname } />;\n', {extends: 'xo-react', prettier: true, filename: 'test.jsx'});
+	const {results} = xo.lintText('<Hello name={ firstname } />;\n', {extends: 'xo-react', prettier: true, filename: 'test.jsx'});
 	// `react/jsx-curly-spacing` is disabled by `eslint-config-prettier`
 	t.false(hasRule(results, 'react/jsx-curly-spacing'));
 	// `prettier/prettier` is enabled
@@ -125,7 +125,7 @@ test('extends `react` support with `prettier` option', t => {
 });
 
 test('regression test for #71', t => {
-	const {results} = fn.lintText('const foo = { key: \'value\' };\nconsole.log(foo);\n', {
+	const {results} = xo.lintText('const foo = { key: \'value\' };\nconsole.log(foo);\n', {
 		extends: path.join(__dirname, 'fixtures/extends.js')
 	});
 	t.is(results[0].errorCount, 0);
@@ -134,15 +134,15 @@ test('regression test for #71', t => {
 test('lintText() - overrides support', async t => {
 	const cwd = path.join(__dirname, 'fixtures/overrides');
 	const bar = path.join(cwd, 'test/bar.js');
-	const barResults = fn.lintText(await readFile(bar, 'utf8'), {filename: bar, cwd}).results;
+	const barResults = xo.lintText(await readFile(bar, 'utf8'), {filename: bar, cwd}).results;
 	t.is(barResults[0].errorCount, 0);
 
 	const foo = path.join(cwd, 'test/foo.js');
-	const fooResults = fn.lintText(await readFile(foo, 'utf8'), {filename: foo, cwd}).results;
+	const fooResults = xo.lintText(await readFile(foo, 'utf8'), {filename: foo, cwd}).results;
 	t.is(fooResults[0].errorCount, 0);
 
 	const index = path.join(cwd, 'test/index.js');
-	const indexResults = fn.lintText(await readFile(bar, 'utf8'), {filename: index, cwd}).results;
+	const indexResults = xo.lintText(await readFile(bar, 'utf8'), {filename: index, cwd}).results;
 	t.is(indexResults[0].errorCount, 0);
 });
 
@@ -150,14 +150,14 @@ test('do not lint gitignored files if filename is given', async t => {
 	const cwd = path.join(__dirname, 'fixtures/gitignore');
 	const ignoredPath = path.resolve('fixtures/gitignore/test/foo.js');
 	const ignored = await readFile(ignoredPath, 'utf8');
-	const {results} = fn.lintText(ignored, {filename: ignoredPath, cwd});
+	const {results} = xo.lintText(ignored, {filename: ignoredPath, cwd});
 	t.is(results[0].errorCount, 0);
 });
 
 test('lint gitignored files if filename is not given', async t => {
 	const ignoredPath = path.resolve('fixtures/gitignore/test/foo.js');
 	const ignored = await readFile(ignoredPath, 'utf8');
-	const {results} = fn.lintText(ignored);
+	const {results} = xo.lintText(ignored);
 	t.true(results[0].errorCount > 0);
 });
 
@@ -165,7 +165,7 @@ test('do not lint gitignored files in file with negative gitignores', async t =>
 	const cwd = path.join(__dirname, 'fixtures/negative-gitignore');
 	const ignoredPath = path.resolve('fixtures/negative-gitignore/bar.js');
 	const ignored = await readFile(ignoredPath, 'utf8');
-	const {results} = fn.lintText(ignored, {filename: ignoredPath, cwd});
+	const {results} = xo.lintText(ignored, {filename: ignoredPath, cwd});
 	t.is(results[0].errorCount, 0);
 });
 
@@ -173,14 +173,14 @@ test('multiple negative patterns should act as positive patterns', async t => {
 	const cwd = path.join(__dirname, 'fixtures', 'gitignore-multiple-negation');
 	const filename = path.join(cwd, '!!!unicorn.js');
 	const text = await readFile(filename, 'utf8');
-	const {results} = fn.lintText(text, {filename, cwd});
+	const {results} = xo.lintText(text, {filename, cwd});
 	t.is(results[0].errorCount, 0);
 });
 
 test('lint negatively gitignored files', async t => {
 	const cwd = path.join(__dirname, 'fixtures/negative-gitignore');
 	const glob = path.posix.join(cwd, '*');
-	const {results} = await fn.lintFiles(glob, {cwd});
+	const {results} = await xo.lintFiles(glob, {cwd});
 
 	t.true(results[0].errorCount > 0);
 });
@@ -189,14 +189,14 @@ test('do not lint eslintignored files if filename is given', async t => {
 	const cwd = path.join(__dirname, 'fixtures/eslintignore');
 	const ignoredPath = path.resolve('fixtures/eslintignore/bar.js');
 	const ignored = await readFile(ignoredPath, 'utf8');
-	const {results} = fn.lintText(ignored, {filename: ignoredPath, cwd});
+	const {results} = xo.lintText(ignored, {filename: ignoredPath, cwd});
 	t.is(results[0].errorCount, 0);
 });
 
 test('lint eslintignored files if filename is not given', async t => {
 	const ignoredPath = path.resolve('fixtures/eslintignore/bar.js');
 	const ignored = await readFile(ignoredPath, 'utf8');
-	const {results} = fn.lintText(ignored);
+	const {results} = xo.lintText(ignored);
 	t.true(results[0].errorCount > 0);
 });
 
@@ -205,10 +205,10 @@ test('enable rules based on nodeVersion', async t => {
 	const filename = path.join(cwd, 'promise-then.js');
 	const text = await readFile(filename, 'utf8');
 
-	let {results} = fn.lintText(text, {nodeVersion: '>=8.0.0'});
+	let {results} = xo.lintText(text, {nodeVersion: '>=8.0.0'});
 	t.true(hasRule(results, 'promise/prefer-await-to-then'));
 
-	({results} = fn.lintText(text, {nodeVersion: '>=6.0.0'}));
+	({results} = xo.lintText(text, {nodeVersion: '>=6.0.0'}));
 	t.false(hasRule(results, 'promise/prefer-await-to-then'));
 });
 
@@ -217,7 +217,7 @@ test('enable rules based on nodeVersion in override', async t => {
 	const filename = path.join(cwd, 'promise-then.js');
 	const text = await readFile(filename, 'utf8');
 
-	let {results} = fn.lintText(text, {
+	let {results} = xo.lintText(text, {
 		nodeVersion: '>=8.0.0',
 		filename: 'promise-then.js',
 		overrides: [
@@ -228,7 +228,7 @@ test('enable rules based on nodeVersion in override', async t => {
 		]});
 	t.false(hasRule(results, 'promise/prefer-await-to-then'));
 
-	({results} = fn.lintText(text, {
+	({results} = xo.lintText(text, {
 		nodeVersion: '>=6.0.0',
 		filename: 'promise-then.js',
 		overrides: [
@@ -241,61 +241,61 @@ test('enable rules based on nodeVersion in override', async t => {
 });
 
 test('allow unassigned stylesheet imports', t => {
-	let {results} = fn.lintText('import \'stylesheet.css\'');
+	let {results} = xo.lintText('import \'stylesheet.css\'');
 	t.false(hasRule(results, 'import/no-unassigned-import'));
 
-	({results} = fn.lintText('import \'stylesheet.scss\''));
+	({results} = xo.lintText('import \'stylesheet.scss\''));
 	t.false(hasRule(results, 'import/no-unassigned-import'));
 
-	({results} = fn.lintText('import \'stylesheet.sass\''));
+	({results} = xo.lintText('import \'stylesheet.sass\''));
 	t.false(hasRule(results, 'import/no-unassigned-import'));
 
-	({results} = fn.lintText('import \'stylesheet.less\''));
+	({results} = xo.lintText('import \'stylesheet.less\''));
 	t.false(hasRule(results, 'import/no-unassigned-import'));
 });
 
 test('find configurations close to linted file', t => {
-	let {results} = fn.lintText('console.log(\'semicolon\');\n', {filename: 'fixtures/nested-configs/child/semicolon.js'});
+	let {results} = xo.lintText('console.log(\'semicolon\');\n', {filename: 'fixtures/nested-configs/child/semicolon.js'});
 	t.true(hasRule(results, 'semi'));
 
-	({results} = fn.lintText('console.log(\'semicolon\');\n', {filename: 'fixtures/nested-configs/child-override/child-prettier-override/semicolon.js'}));
+	({results} = xo.lintText('console.log(\'semicolon\');\n', {filename: 'fixtures/nested-configs/child-override/child-prettier-override/semicolon.js'}));
 	t.true(hasRule(results, 'prettier/prettier'));
 
-	({results} = fn.lintText('console.log(\'no-semicolon\')\n', {filename: 'fixtures/nested-configs/no-semicolon.js'}));
+	({results} = xo.lintText('console.log(\'no-semicolon\')\n', {filename: 'fixtures/nested-configs/no-semicolon.js'}));
 	t.true(hasRule(results, 'semi'));
 
-	({results} = fn.lintText(`console.log([
+	({results} = xo.lintText(`console.log([
   2
 ]);\n`, {filename: 'fixtures/nested-configs/child-override/two-spaces.js'}));
 	t.true(hasRule(results, 'indent'));
 });
 
 test('typescript files', t => {
-	let {results} = fn.lintText(`console.log([
+	let {results} = xo.lintText(`console.log([
   2
 ]);
 `, {filename: 'fixtures/typescript/two-spaces.tsx'});
 	t.true(hasRule(results, '@typescript-eslint/indent'));
 
-	({results} = fn.lintText(`console.log([
+	({results} = xo.lintText(`console.log([
   2
 ]);
 `, {filename: 'fixtures/typescript/two-spaces.tsx', space: 2}));
 	t.is(results[0].errorCount, 0);
 
-	({results} = fn.lintText('console.log(\'extra-semicolon\');;\n', {filename: 'fixtures/typescript/child/extra-semicolon.ts'}));
+	({results} = xo.lintText('console.log(\'extra-semicolon\');;\n', {filename: 'fixtures/typescript/child/extra-semicolon.ts'}));
 	t.true(hasRule(results, '@typescript-eslint/no-extra-semi'));
 
-	({results} = fn.lintText('console.log(\'no-semicolon\')\n', {filename: 'fixtures/typescript/child/no-semicolon.ts', semicolon: false}));
+	({results} = xo.lintText('console.log(\'no-semicolon\')\n', {filename: 'fixtures/typescript/child/no-semicolon.ts', semicolon: false}));
 	t.is(results[0].errorCount, 0);
 
-	({results} = fn.lintText(`console.log([
+	({results} = xo.lintText(`console.log([
     4
 ]);
 `, {filename: 'fixtures/typescript/child/sub-child/four-spaces.ts'}));
 	t.true(hasRule(results, '@typescript-eslint/indent'));
 
-	({results} = fn.lintText(`console.log([
+	({results} = xo.lintText(`console.log([
     4
 ]);
 `, {filename: 'fixtures/typescript/child/sub-child/four-spaces.ts', space: 4}));
@@ -303,7 +303,7 @@ test('typescript files', t => {
 });
 
 function configType(t, {dir}) {
-	const {results} = fn.lintText('var obj = { a: 1 };\n', {cwd: path.resolve('fixtures', 'config-files', dir), filename: 'file.js'});
+	const {results} = xo.lintText('var obj = { a: 1 };\n', {cwd: path.resolve('fixtures', 'config-files', dir), filename: 'file.js'});
 	t.true(hasRule(results, 'no-var'));
 }
 

--- a/test/open-report.js
+++ b/test/open-report.js
@@ -1,13 +1,13 @@
 import path from 'path';
 import test from 'ava';
 import proxyquire from 'proxyquire';
-import fn from '..';
+import xo from '..';
 
 process.chdir(__dirname);
 
 test('opens nothing when there are no errors nor warnings', async t => {
 	const glob = path.join(__dirname, 'fixtures/open-report/successes/*');
-	const results = await fn.lintFiles(glob);
+	const results = await xo.lintFiles(glob);
 
 	const openReport = proxyquire('../lib/open-report', {
 		'open-editor': files => {
@@ -23,7 +23,7 @@ test('opens nothing when there are no errors nor warnings', async t => {
 
 test('only opens errors if there are errors and warnings', async t => {
 	const glob = path.join(__dirname, 'fixtures/open-report/**');
-	const results = await fn.lintFiles(glob);
+	const results = await xo.lintFiles(glob);
 
 	const expected = [
 		{
@@ -53,7 +53,7 @@ test('only opens errors if there are errors and warnings', async t => {
 
 test('if a file has errors and warnings, it opens the first error', async t => {
 	const glob = path.join(__dirname, 'fixtures/open-report/errors/two-with-warnings.js');
-	const results = await fn.lintFiles(glob);
+	const results = await xo.lintFiles(glob);
 
 	const expected = [
 		{
@@ -71,7 +71,7 @@ test('if a file has errors and warnings, it opens the first error', async t => {
 
 test('only opens warnings if there are no errors', async t => {
 	const glob = path.join(__dirname, 'fixtures/open-report/warnings/*');
-	const results = await fn.lintFiles(glob);
+	const results = await xo.lintFiles(glob);
 
 	const expected = [
 		{

--- a/test/print-config.js
+++ b/test/print-config.js
@@ -1,0 +1,26 @@
+import path from 'path';
+import test from 'ava';
+import execa from 'execa';
+import tempWrite from 'temp-write';
+import xo from '..';
+
+process.chdir(__dirname);
+
+const main = (arguments_, options) => execa(path.join(__dirname, '../cli-main.js'), arguments_, options);
+
+const hasUnicornPlugin = config => config.plugins.includes('unicorn');
+const hasPrintConfigGlobal = config => Object.keys(config.globals).includes('printConfig');
+
+test('getConfig', async t => {
+	const filepath = await tempWrite('console.log()\n', 'x.js');
+	const options = {filename: filepath, globals: ['printConfig']};
+	const result = xo.getConfig(options);
+	t.true(hasUnicornPlugin(result) && hasPrintConfigGlobal(result));
+});
+
+test('print-config option', async t => {
+	const filepath = await tempWrite('console.log()\n', 'x.js');
+	const {stdout} = await main(['--global=printConfig', '--print-config', filepath]);
+	const result = JSON.parse(stdout);
+	t.true(hasUnicornPlugin(result) && hasPrintConfigGlobal(result));
+});


### PR DESCRIPTION
I often find myself needing this option to figure out which rules XO is using. If I learn about a new ESLint rule, I want to be able to check whether XO already enables it or something similar; if I upgrade XO, I want to be able to check whether it disabled any rules I was relying on; I want to be able to check that I configured `overrides` correctly and that it’s applied in the order I expect; etc.

This was largely based on #312 by @teehemkay.