### PR TITLE
Move from deprecated `ESLint.CLIEngine` to `ESLint`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,19 @@
 'use strict';
 const path = require('path');
-const eslint = require('eslint');
+const {ESLint} = require('eslint');
 const globby = require('globby');
 const isEqual = require('lodash/isEqual');
 const uniq = require('lodash/uniq');
+const pick = require('lodash/pick');
+const omit = require('lodash/omit');
 const micromatch = require('micromatch');
 const arrify = require('arrify');
 const pReduce = require('p-reduce');
+const pMap = require('p-map');
 const {cosmiconfig, defaultLoaders} = require('cosmiconfig');
-const {CONFIG_FILES, MODULE_NAME, DEFAULT_IGNORES} = require('./lib/constants');
+const defineLazyProperty = require('define-lazy-prop');
+const pFilter = require('p-filter');
+const {CONFIG_FILES, MODULE_NAME, DEFAULT_IGNORES, LINT_METHOD_OPTIONS} = require('./lib/constants');
 const {
 	normalizeOptions,
 	getIgnores,
@@ -19,36 +24,85 @@ const {
 } = require('./lib/options-manager');
 
 const mergeReports = reports => {
-	// Merge multiple reports into a single report
 	let results = [];
 	let errorCount = 0;
 	let warningCount = 0;
 
 	for (const report of reports) {
-		results = results.concat(report.results);
+		results = results.concat(...report.results);
 		errorCount += report.errorCount;
 		warningCount += report.warningCount;
 	}
 
 	return {
+		results,
 		errorCount,
-		warningCount,
-		results
+		warningCount
 	};
 };
 
-const processReport = (report, options) => {
-	report.results = options.quiet ? eslint.CLIEngine.getErrorResults(report.results) : report.results;
-	return report;
+function getReportStatistics(results) {
+	let errorCount = 0;
+	let warningCount = 0;
+	let fixableErrorCount = 0;
+	let fixableWarningCount = 0;
+
+	for (const {
+		errorCount: currentErrorCount,
+		warningCount: currentWarningCount,
+		fixableErrorCount: currentFixableErrorCount,
+		fixableWarningCount: currentFixableWarningCount
+	} of results) {
+		errorCount += currentErrorCount;
+		warningCount += currentWarningCount;
+		fixableErrorCount += currentFixableErrorCount;
+		fixableWarningCount += currentFixableWarningCount;
+	}
+
+	return {
+		errorCount,
+		warningCount,
+		fixableErrorCount,
+		fixableWarningCount
+	};
+}
+
+const processReport = (report, {isQuiet = false} = {}) => {
+	if (isQuiet) {
+		report = ESLint.getErrorResults(report);
+	}
+
+	const result = {
+		results: report,
+		...getReportStatistics(report)
+	};
+
+	defineLazyProperty(result, 'usedDeprecatedRules', () => {
+		const seenRules = new Set();
+		const rules = [];
+
+		for (const {usedDeprecatedRules} of report) {
+			for (const rule of usedDeprecatedRules) {
+				if (seenRules.has(rule.ruleId)) {
+					continue;
+				}
+
+				seenRules.add(rule.ruleId);
+				rules.push(rule);
+			}
+		}
+
+		return rules;
+	});
+
+	return result;
 };
 
-const runEslint = (paths, options) => {
-	const engine = new eslint.CLIEngine(options);
-	const report = engine.executeOnFiles(
-		paths.filter(path => !engine.isPathIgnored(path)),
-		options
-	);
-	return processReport(report, options);
+const runEslint = async (paths, options, processorOptions) => {
+	const engine = new ESLint(options);
+
+	const report = await engine.lintFiles(await pFilter(paths, async path => !(await engine.isPathIgnored(path))));
+	return processReport(report, processorOptions);
 };
 
 const globFiles = async (patterns, {ignores, extensions, cwd}) => (
@@ -57,30 +111,30 @@ const globFiles = async (patterns, {ignores, extensions, cwd}) => (
 		{ignore: ignores, gitignore: true, cwd}
 	)).filter(file => extensions.includes(path.extname(file).slice(1))).map(file => path.resolve(cwd, file));
 
-const getConfig = options => {
+const getConfig = async options => {
 	const {options: foundOptions, prettierOptions} = mergeWithFileConfig(normalizeOptions(options));
 	options = buildConfig(foundOptions, prettierOptions);
-	const engine = new eslint.CLIEngine(options);
-	return engine.getConfigForFile(options.filename);
+	const engine = new ESLint(omit(options, LINT_METHOD_OPTIONS));
+	return engine.calculateConfigForFile(options.filePath);
 };
 
-const lintText = (string, options) => {
-	const {options: foundOptions, prettierOptions} = mergeWithFileConfig(normalizeOptions(options));
-	options = buildConfig(foundOptions, prettierOptions);
+const lintText = async (string, inputOptions = {}) => {
+	const {options: foundOptions, prettierOptions} = mergeWithFileConfig(normalizeOptions(inputOptions));
+	const options = buildConfig(foundOptions, prettierOptions);
 
-	if (options.ignores && !isEqual(getIgnores({}), options.ignores) && typeof options.filename !== 'string') {
-		throw new Error('The `ignores` option requires the `filename` option to be defined.');
+	if (options.baseConfig.ignorePatterns && !isEqual(getIgnores({}), options.baseConfig.ignorePatterns) && typeof options.filePath !== 'string') {
+		throw new Error('The `ignores` option requires the `filePath` option to be defined.');
 	}
 
-	const engine = new eslint.CLIEngine(options);
+	const engine = new ESLint(omit(options, LINT_METHOD_OPTIONS));
 
-	if (options.filename) {
-		const filename = path.relative(options.cwd, options.filename);
+	if (options.filePath) {
+		const filename = path.relative(options.cwd, options.filePath);
 
 		if (
-			micromatch.isMatch(filename, options.ignores) ||
-			globby.gitignore.sync({cwd: options.cwd, ignore: options.ignores})(options.filename) ||
-			engine.isPathIgnored(options.filename)
+			micromatch.isMatch(filename, options.baseConfig.ignorePatterns) ||
+			globby.gitignore.sync({cwd: options.cwd, ignore: options.baseConfig.ignorePatterns})(options.filePath) ||
+			await engine.isPathIgnored(options.filePath)
 		) {
 			return {
 				errorCount: 0,
@@ -95,39 +149,42 @@ const lintText = (string, options) => {
 		}
 	}
 
-	const report = engine.executeOnText(string, options.filename);
+	const report = await engine.lintText(string, pick(options, LINT_METHOD_OPTIONS));
 
-	return processReport(report, options);
+	return processReport(report, {isQuiet: inputOptions.quiet});
 };
 
-const lintFiles = async (patterns, options = {}) => {
-	options.cwd = path.resolve(options.cwd || process.cwd());
-	const configExplorer = cosmiconfig(MODULE_NAME, {searchPlaces: CONFIG_FILES, loaders: {noExt: defaultLoaders['.json']}, stopDir: options.cwd});
+const lintFiles = async (patterns, inputOptions = {}) => {
+	inputOptions.cwd = path.resolve(inputOptions.cwd || process.cwd());
+	const configExplorer = cosmiconfig(MODULE_NAME, {searchPlaces: CONFIG_FILES, loaders: {noExt: defaultLoaders['.json']}, stopDir: inputOptions.cwd});
 
 	const configFiles = (await Promise.all(
 		(await globby(
 			CONFIG_FILES.map(configFile => `**/${configFile}`),
-			{ignore: DEFAULT_IGNORES, gitignore: true, cwd: options.cwd}
-		)).map(async configFile => configExplorer.load(path.resolve(options.cwd, configFile)))
+			{ignore: DEFAULT_IGNORES, gitignore: true, cwd: inputOptions.cwd}
+		)).map(async configFile => configExplorer.load(path.resolve(inputOptions.cwd, configFile)))
 	)).filter(Boolean);
 
 	const paths = configFiles.length > 0 ?
 		await pReduce(
 			configFiles,
 			async (paths, {filepath, config}) =>
-				[...paths, ...(await globFiles(patterns, {...mergeOptions(options, config), cwd: path.dirname(filepath)}))],
+				[...paths, ...(await globFiles(patterns, {...mergeOptions(inputOptions, config), cwd: path.dirname(filepath)}))],
 			[]) :
-		await globFiles(patterns, mergeOptions(options));
+		await globFiles(patterns, mergeOptions(inputOptions));
 
-	return mergeReports((await mergeWithFileConfigs(uniq(paths), options, configFiles)).map(
-		({files, options, prettierOptions}) => runEslint(files, buildConfig(options, prettierOptions)))
-	);
+	return mergeReports(await pMap(await mergeWithFileConfigs(uniq(paths), inputOptions, configFiles), async ({files, options, prettierOptions}) => runEslint(files, buildConfig(options, prettierOptions), {isQuiet: options.quiet})));
+};
+
+const getFormatter = async name => {
+	const {format} = await new ESLint().loadFormatter(name);
+	return format;
 };
 
 module.exports = {
-	getFormatter: eslint.CLIEngine.getFormatter,
-	getErrorResults: eslint.CLIEngine.getErrorResults,
-	outputFixes: eslint.CLIEngine.outputFixes,
+	getFormatter,
+	getErrorResults: ESLint.getErrorResults,
+	outputFixes: async ({results}) => ESLint.outputFixes(results),
 	getConfig,
 	lintText,
 	lintFiles

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -137,6 +137,8 @@ const TSCONFIG_DEFFAULTS = {
 
 const CACHE_DIR_NAME = 'xo-linter';
 
+const LINT_METHOD_OPTIONS = ['filePath', 'warnIgnored'];
+
 module.exports = {
 	DEFAULT_IGNORES,
 	DEFAULT_EXTENSION,
@@ -147,5 +149,6 @@ module.exports = {
 	CONFIG_FILES,
 	MERGE_OPTIONS_CONCAT,
 	TSCONFIG_DEFFAULTS,
-	CACHE_DIR_NAME
+	CACHE_DIR_NAME,
+	LINT_METHOD_OPTIONS
 };

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -333,7 +333,10 @@ const buildESLintConfig = options => config => {
 		];
 	}
 
-	Object.assign(config, pick(options, ['cwd', 'filePath', 'fix']));
+	config = {
+		...config,
+		...pick(options, ['cwd', 'filePath', 'fix'])
+	};
 
 	return config;
 };

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -7,6 +7,7 @@ const arrify = require('arrify');
 const mergeWith = require('lodash/mergeWith');
 const groupBy = require('lodash/groupBy');
 const flow = require('lodash/flow');
+const pick = require('lodash/pick');
 const pathExists = require('path-exists');
 const findUp = require('find-up');
 const findCacheDir = require('find-cache-dir');
@@ -21,6 +22,7 @@ const toAbsoluteGlob = require('to-absolute-glob');
 const stringify = require('json-stable-stringify-without-jsonify');
 const murmur = require('imurmurhash');
 const isPathInside = require('is-path-inside');
+const {normalizePackageName} = require('@eslint/eslintrc/lib/shared/naming');
 const {
 	DEFAULT_IGNORES,
 	DEFAULT_EXTENSION,
@@ -54,7 +56,19 @@ const DEFAULT_CONFIG = {
 /**
 Define the shape of deep properties for `mergeWith`.
 */
-const getEmptyOptions = () => ({
+const getEmptyConfig = () => ({
+	baseConfig: {
+		rules: {},
+		settings: {},
+		globals: {},
+		ignorePatterns: [],
+		env: {},
+		plugins: [],
+		extends: []
+	}
+});
+
+const getEmptyXOConfig = () => ({
 	rules: {},
 	settings: {},
 	globals: [],
@@ -77,17 +91,17 @@ const isTypescript = file => TYPESCRIPT_EXTENSION.includes(path.extname(file).sl
 
 /**
 Find config for `lintText`.
-The config files are searched starting from `options.filename` if defined or `options.cwd` otherwise.
+The config files are searched starting from `options.filePath` if defined or `options.cwd` otherwise.
 */
 const mergeWithFileConfig = options => {
 	options.cwd = path.resolve(options.cwd || process.cwd());
 	const configExplorer = cosmiconfigSync(MODULE_NAME, {searchPlaces: CONFIG_FILES, loaders: {noExt: defaultLoaders['.json']}, stopDir: options.cwd});
 	const pkgConfigExplorer = cosmiconfigSync('engines', {searchPlaces: ['package.json'], stopDir: options.cwd});
-	if (options.filename) {
-		options.filename = path.resolve(options.cwd, options.filename);
+	if (options.filePath) {
+		options.filePath = path.resolve(options.cwd, options.filePath);
 	}
 
-	const searchPath = options.filename || options.cwd;
+	const searchPath = options.filePath || options.cwd;
 
 	const {config: xoOptions, filepath: xoConfigPath} = configExplorer.search(searchPath) || {};
 	const {config: enginesOptions} = pkgConfigExplorer.search(searchPath) || {};
@@ -95,19 +109,19 @@ const mergeWithFileConfig = options => {
 	options = mergeOptions(options, xoOptions, enginesOptions);
 	options.cwd = xoConfigPath && path.dirname(xoConfigPath) !== options.cwd ? path.resolve(options.cwd, path.dirname(xoConfigPath)) : options.cwd;
 
-	if (options.filename) {
-		({options} = applyOverrides(options.filename, options));
+	if (options.filePath) {
+		({options} = applyOverrides(options.filePath, options));
 	}
 
 	const prettierOptions = options.prettier ? prettier.resolveConfig.sync(searchPath, {editorconfig: true}) || {} : {};
 
-	if (options.filename && isTypescript(options.filename)) {
+	if (options.filePath && isTypescript(options.filePath)) {
 		const tsConfigExplorer = cosmiconfigSync([], {searchPlaces: ['tsconfig.json'], loaders: {'.json': (_, content) => JSON5.parse(content)}});
-		const {config: tsConfig, filepath: tsConfigPath} = tsConfigExplorer.search(options.filename) || {};
+		const {config: tsConfig, filepath: tsConfigPath} = tsConfigExplorer.search(options.filePath) || {};
 
-		options.tsConfigPath = getTsConfigCachePath([options.filename], options.tsConfigPath);
+		options.tsConfigPath = getTsConfigCachePath([options.filePath], options.tsConfigPath);
 		options.ts = true;
-		outputJsonSync(options.tsConfigPath, makeTSConfig(tsConfig, tsConfigPath, [options.filename]));
+		outputJsonSync(options.tsConfigPath, makeTSConfig(tsConfig, tsConfigPath, [options.filePath]));
 	}
 
 	return {options, prettierOptions};
@@ -236,7 +250,7 @@ const normalizeOptions = options => {
 const normalizeSpaces = options => typeof options.space === 'number' ? options.space : 2;
 
 /**
-Merge option passed via CLI/API via options founf in config files.
+Merge option passed via CLI/API via options found in config files.
 */
 const mergeOptions = (options, xoOptions = {}, enginesOptions = {}) => {
 	const mergedOptions = normalizeOptions({
@@ -257,72 +271,26 @@ Transform an XO options into ESLint compatible options:
 - Resolve the extended configurations.
 - Apply rules based on Prettier config if `prettier` option is `true`.
 */
-const buildConfig = (options, prettierOptions) =>
-	flow(
+const buildConfig = (options, prettierOptions) => {
+	options = normalizeOptions(options);
+
+	return flow(
+		buildESLintConfig(options),
 		buildXOConfig(options),
 		buildTSConfig(options),
 		buildExtendsConfig(options),
 		buildPrettierConfig(options, prettierOptions)
-	)(mergeWith(getEmptyOptions(), DEFAULT_CONFIG, normalizeOptions(options), mergeFn));
+	)(mergeWith(getEmptyConfig(), DEFAULT_CONFIG, mergeFn));
+};
 
-const buildXOConfig = options => config => {
-	const spaces = normalizeSpaces(options);
+const toValueMap = (array, value = true) => Object.fromEntries(array.map(item => [item, value]));
 
-	for (const [rule, ruleConfig] of Object.entries(ENGINE_RULES)) {
-		for (const minVersion of Object.keys(ruleConfig).sort(semver.rcompare)) {
-			if (!options.nodeVersion || semver.intersects(options.nodeVersion, `<${minVersion}`)) {
-				config.rules[rule] = ruleConfig[minVersion];
-			}
-		}
-	}
-
-	if (options.nodeVersion) {
-		config.rules['node/no-unsupported-features/es-builtins'] = ['error', {version: options.nodeVersion}];
-		config.rules['node/no-unsupported-features/es-syntax'] = ['error', {version: options.nodeVersion, ignores: ['modules']}];
-		config.rules['node/no-unsupported-features/node-builtins'] = ['error', {version: options.nodeVersion}];
-	}
-
-	if (options.space && !options.prettier) {
-		if (options.ts) {
-			config.rules['@typescript-eslint/indent'] = ['error', spaces, {SwitchCase: 1}];
-		} else {
-			config.rules.indent = ['error', spaces, {SwitchCase: 1}];
-		}
-
-		// Only apply if the user has the React plugin
-		if (options.cwd && resolveFrom.silent(options.cwd, 'eslint-plugin-react')) {
-			config.plugins = config.plugins.concat('react');
-			config.rules['react/jsx-indent-props'] = ['error', spaces];
-			config.rules['react/jsx-indent'] = ['error', spaces];
-		}
-	}
-
-	if (options.semicolon === false && !options.prettier) {
-		if (options.ts) {
-			config.rules['@typescript-eslint/semi'] = ['error', 'never'];
-		} else {
-			config.rules.semi = ['error', 'never'];
-		}
-
-		config.rules['semi-spacing'] = ['error', {
-			before: false,
-			after: true
-		}];
-	}
-
-	if (options.ts) {
-		config.rules['unicorn/import-style'] = 'off';
-		config.rules['node/file-extension-in-import'] = 'off';
-
-		// Disabled because of https://github.com/benmosher/eslint-plugin-import/issues/1590
-		config.rules['import/export'] = 'off';
-
-		// Does not work when the TS definition exports a default const.
-		config.rules['import/default'] = 'off';
-	}
-
+const buildESLintConfig = options => config => {
 	if (options.rules) {
-		Object.assign(config.rules, options.rules);
+		config.baseConfig.rules = {
+			...config.baseConfig.rules,
+			...options.rules
+		};
 	}
 
 	if (options.parser) {
@@ -336,33 +304,112 @@ const buildXOConfig = options => config => {
 	config.baseConfig.settings = options.settings || {};
 	config.baseConfig.settings['import/resolver'] = gatherImportResolvers(options);
 
+	if (options.envs) {
+		config.baseConfig.env = {
+			...config.baseConfig.env,
+			...toValueMap(options.envs)
+		};
+	}
+
+	if (options.globals) {
+		config.baseConfig.globals = {
+			...config.baseConfig.globals,
+			...toValueMap(options.globals, 'readonly')
+		};
+	}
+
+	if (options.plugins) {
+		config.baseConfig.plugins = [
+			...config.baseConfig.plugins,
+			...options.plugins
+		];
+	}
+
+	if (options.ignores) {
+		config.baseConfig.ignorePatterns = [
+			...config.baseConfig.ignorePatterns,
+			...options.ignores
+		];
+	}
+
+	Object.assign(config, pick(options, ['cwd', 'filePath', 'fix']));
+
+	return config;
+};
+
+const buildXOConfig = options => config => {
+	const spaces = normalizeSpaces(options);
+
+	for (const [rule, ruleConfig] of Object.entries(ENGINE_RULES)) {
+		for (const minVersion of Object.keys(ruleConfig).sort(semver.rcompare)) {
+			if (!options.nodeVersion || semver.intersects(options.nodeVersion, `<${minVersion}`)) {
+				config.baseConfig.rules[rule] = ruleConfig[minVersion];
+			}
+		}
+	}
+
+	if (options.nodeVersion) {
+		config.baseConfig.rules['node/no-unsupported-features/es-builtins'] = ['error', {version: options.nodeVersion}];
+		config.baseConfig.rules['node/no-unsupported-features/es-syntax'] = ['error', {version: options.nodeVersion, ignores: ['modules']}];
+		config.baseConfig.rules['node/no-unsupported-features/node-builtins'] = ['error', {version: options.nodeVersion}];
+	}
+
+	if (options.space && !options.prettier) {
+		if (options.ts) {
+			config.baseConfig.rules['@typescript-eslint/indent'] = ['error', spaces, {SwitchCase: 1}];
+		} else {
+			config.baseConfig.rules.indent = ['error', spaces, {SwitchCase: 1}];
+		}
+
+		// Only apply if the user has the React plugin
+		if (options.cwd && resolveFrom.silent(options.cwd, 'eslint-plugin-react')) {
+			config.baseConfig.plugins = config.baseConfig.plugins.concat('react');
+			config.baseConfig.rules['react/jsx-indent-props'] = ['error', spaces];
+			config.baseConfig.rules['react/jsx-indent'] = ['error', spaces];
+		}
+	}
+
+	if (options.semicolon === false && !options.prettier) {
+		if (options.ts) {
+			config.baseConfig.rules['@typescript-eslint/semi'] = ['error', 'never'];
+		} else {
+			config.baseConfig.rules.semi = ['error', 'never'];
+		}
+
+		config.baseConfig.rules['semi-spacing'] = ['error', {
+			before: false,
+			after: true
+		}];
+	}
+
+	if (options.ts) {
+		config.baseConfig.rules['unicorn/import-style'] = 'off';
+		config.baseConfig.rules['node/file-extension-in-import'] = 'off';
+
+		// Disabled because of https://github.com/benmosher/eslint-plugin-import/issues/1590
+		config.baseConfig.rules['import/export'] = 'off';
+
+		// Does not work when the TS definition exports a default const.
+		config.baseConfig.rules['import/default'] = 'off';
+	}
+
 	return config;
 };
 
 const buildExtendsConfig = options => config => {
 	if (options.extends && options.extends.length > 0) {
-		// TODO: This logic needs to be improved, preferably use the same code as ESLint
-		// user's configs must be resolved to their absolute paths
 		const configs = options.extends.map(name => {
 			// Don't do anything if it's a filepath
 			if (pathExists.sync(name)) {
 				return name;
 			}
 
-			// Don't do anything if it's a config from a plugin
-			if (name.startsWith('plugin:')) {
+			// Don't do anything if it's a config from a plugin or an internal eslint config
+			if (name.startsWith('eslint:') || name.startsWith('plugin:')) {
 				return name;
 			}
 
-			if (name.startsWith('@')) {
-				return name;
-			}
-
-			if (!name.includes('eslint-config-')) {
-				name = `eslint-config-${name}`;
-			}
-
-			const returnValue = resolveFrom(options.cwd, name);
+			const returnValue = resolveFrom(options.cwd, normalizePackageName(name, 'eslint-config'));
 
 			if (!returnValue) {
 				throw new Error(`Couldn't find ESLint config: ${name}`);
@@ -380,13 +427,13 @@ const buildExtendsConfig = options => config => {
 const buildPrettierConfig = (options, prettierConfig) => config => {
 	if (options.prettier) {
 		// The prettier plugin uses Prettier to format the code with `--fix`
-		config.plugins = config.plugins.concat('prettier');
+		config.baseConfig.plugins = config.baseConfig.plugins.concat('prettier');
 
 		// The prettier config overrides ESLint stylistic rules that are handled by Prettier
 		config.baseConfig.extends = config.baseConfig.extends.concat('prettier');
 
 		// The `prettier/prettier` rule reports errors if the code is not formatted in accordance to Prettier
-		config.rules['prettier/prettier'] = ['error', mergeWithPrettierConfig(options, prettierConfig)];
+		config.baseConfig.rules['prettier/prettier'] = ['error', mergeWithPrettierConfig(options, prettierConfig)];
 
 		// If the user has the React, Flowtype, or Standard plugin, add the corresponding Prettier rule overrides
 		// See https://github.com/prettier/eslint-config-prettier for the list of plugins overrrides
@@ -459,7 +506,7 @@ const applyOverrides = (file, options) => {
 
 		const {applicable, hash} = findApplicableOverrides(path.relative(options.cwd, file), overrides);
 
-		options = mergeWith(...[getEmptyOptions(), options].concat(applicable.map(override => normalizeOptions(override)), mergeFn));
+		options = mergeWith(...[getEmptyXOConfig(), options].concat(applicable.map(override => normalizeOptions(override)), mergeFn));
 		delete options.files;
 		return {options, hash};
 	}

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -12,7 +12,6 @@ const fromPairs = require('lodash/fromPairs');
 const pathExists = require('path-exists');
 const findUp = require('find-up');
 const findCacheDir = require('find-cache-dir');
-const resolveFrom = require('resolve-from');
 const prettier = require('prettier');
 const semver = require('semver');
 const {cosmiconfig, cosmiconfigSync, defaultLoaders} = require('cosmiconfig');
@@ -27,6 +26,9 @@ const {
 	Legacy: {
 		naming: {
 			normalizePackageName
+		},
+		ModuleResolver: {
+			resolve: resolveModule
 		}
 	}
 } = require('@eslint/eslintrc');
@@ -43,6 +45,14 @@ const {
 	CACHE_DIR_NAME
 } = require('./constants');
 
+const resolveFrom = (moduleId, fromDirectory = process.cwd()) => resolveModule(moduleId, path.join(fromDirectory, '__placeholder__.js'));
+
+resolveFrom.silent = (moduleId, fromDirectory) => {
+	try {
+		return resolveFrom(moduleId, fromDirectory);
+	} catch { }
+};
+
 const nodeVersion = process && process.version;
 const cacheLocation = findCacheDir({name: CACHE_DIR_NAME}) || path.join(os.homedir() || os.tmpdir(), '.xo-cache/');
 
@@ -53,7 +63,7 @@ const DEFAULT_CONFIG = {
 	globInputPaths: false,
 	baseConfig: {
 		extends: [
-			'xo',
+			resolveFrom('eslint-config-xo'),
 			path.join(__dirname, '../config/overrides.js'),
 			path.join(__dirname, '../config/plugins.js')
 		]
@@ -369,7 +379,7 @@ const buildXOConfig = options => config => {
 		}
 
 		// Only apply if the user has the React plugin
-		if (options.cwd && resolveFrom.silent(options.cwd, 'eslint-plugin-react')) {
+		if (options.cwd && resolveFrom.silent('eslint-plugin-react', options.cwd)) {
 			config.baseConfig.plugins = config.baseConfig.plugins.concat('react');
 			config.baseConfig.rules['react/jsx-indent-props'] = ['error', spaces];
 			config.baseConfig.rules['react/jsx-indent'] = ['error', spaces];
@@ -418,7 +428,7 @@ const buildExtendsConfig = options => config => {
 				return name;
 			}
 
-			const returnValue = resolveFrom(options.cwd, normalizePackageName(name, 'eslint-config'));
+			const returnValue = resolveFrom(normalizePackageName(name, 'eslint-config'), options.cwd);
 
 			if (!returnValue) {
 				throw new Error(`Couldn't find ESLint config: ${name}`);
@@ -447,7 +457,7 @@ const buildPrettierConfig = (options, prettierConfig) => config => {
 		// If the user has the React, Flowtype, or Standard plugin, add the corresponding Prettier rule overrides
 		// See https://github.com/prettier/eslint-config-prettier for the list of plugins overrrides
 		for (const [plugin, prettierConfig] of Object.entries(PRETTIER_CONFIG_OVERRIDE)) {
-			if (options.cwd && resolveFrom.silent(options.cwd, plugin)) {
+			if (options.cwd && resolveFrom.silent(plugin, options.cwd)) {
 				config.baseConfig.extends = config.baseConfig.extends.concat(prettierConfig);
 			}
 		}

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -332,12 +332,10 @@ const buildESLintConfig = options => config => {
 		];
 	}
 
-	config = {
+	return {
 		...config,
 		...pick(options, ['cwd', 'filePath', 'fix'])
 	};
-
-	return config;
 };
 
 const buildXOConfig = options => config => {

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -8,6 +8,7 @@ const mergeWith = require('lodash/mergeWith');
 const groupBy = require('lodash/groupBy');
 const flow = require('lodash/flow');
 const pick = require('lodash/pick');
+const fromPairs = require('lodash/fromPairs');
 const pathExists = require('path-exists');
 const findUp = require('find-up');
 const findCacheDir = require('find-cache-dir');
@@ -283,7 +284,7 @@ const buildConfig = (options, prettierOptions) => {
 	)(mergeWith(getEmptyConfig(), DEFAULT_CONFIG, mergeFn));
 };
 
-const toValueMap = (array, value = true) => Object.fromEntries(array.map(item => [item, value]));
+const toValueMap = (array, value = true) => fromPairs(array.map(item => [item, value]));
 
 const buildESLintConfig = options => config => {
 	if (options.rules) {

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -23,7 +23,13 @@ const toAbsoluteGlob = require('to-absolute-glob');
 const stringify = require('json-stable-stringify-without-jsonify');
 const murmur = require('imurmurhash');
 const isPathInside = require('is-path-inside');
-const {normalizePackageName} = require('@eslint/eslintrc/lib/shared/naming');
+const {
+	Legacy: {
+		naming: {
+			normalizePackageName
+		}
+	}
+} = require('@eslint/eslintrc');
 const {
 	DEFAULT_IGNORES,
 	DEFAULT_EXTENSION,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"typescript"
 	],
 	"dependencies": {
-		"@eslint/eslintrc": "^0.4.0",
+		"@eslint/eslintrc": "^0.4.1",
 		"@typescript-eslint/eslint-plugin": "^4.22.0",
 		"@typescript-eslint/parser": "^4.22.0",
 		"arrify": "^2.0.1",
@@ -92,7 +92,6 @@
 		"path-exists": "^4.0.0",
 		"prettier": "^2.2.1",
 		"resolve-cwd": "^3.0.0",
-		"resolve-from": "^5.0.0",
 		"semver": "^7.3.5",
 		"slash": "^3.0.0",
 		"to-absolute-glob": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
 		"typescript"
 	],
 	"dependencies": {
+		"@eslint/eslintrc": "^0.4.0",
 		"@typescript-eslint/eslint-plugin": "^4.22.0",
 		"@typescript-eslint/parser": "^4.22.0",
 		"arrify": "^2.0.1",
 		"cosmiconfig": "^7.0.0",
 		"debug": "^4.3.1",
+		"define-lazy-prop": "^2.0.0",
 		"eslint": "^7.24.0",
 		"eslint-config-prettier": "^8.2.0",
 		"eslint-config-xo": "^0.36.0",
@@ -84,6 +86,8 @@
 		"meow": "^9.0.0",
 		"micromatch": "^4.0.4",
 		"open-editor": "^3.0.0",
+		"p-filter": "^2.1.0",
+		"p-map": "^4.0.0",
 		"p-reduce": "^2.1.0",
 		"path-exists": "^4.0.0",
 		"prettier": "^2.2.1",

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -29,14 +29,30 @@ test('normalizeOptions: makes all the options plural and arrays', t => {
 	});
 
 	t.deepEqual(options, {
-		envs: ['node'],
-		globals: ['foo'],
-		ignores: ['test.js'],
-		plugins: ['my-plugin'],
-		rules: {'my-rule': 'foo'},
-		settings: {'my-rule': 'bar'},
-		extends: ['foo'],
-		extensions: ['html']
+		envs: [
+			'node'
+		],
+		extends: [
+			'foo'
+		],
+		extensions: [
+			'html'
+		],
+		globals: [
+			'foo'
+		],
+		ignores: [
+			'test.js'
+		],
+		plugins: [
+			'my-plugin'
+		],
+		rules: {
+			'my-rule': 'foo'
+		},
+		settings: {
+			'my-rule': 'bar'
+		}
 	});
 });
 
@@ -54,27 +70,27 @@ test('buildConfig: defaults', t => {
 
 test('buildConfig: space: true', t => {
 	const config = manager.buildConfig({space: true});
-	t.deepEqual(config.rules.indent, ['error', 2, {SwitchCase: 1}]);
+	t.deepEqual(config.baseConfig.rules.indent, ['error', 2, {SwitchCase: 1}]);
 });
 
 test('buildConfig: space: 4', t => {
 	const config = manager.buildConfig({space: 4});
-	t.deepEqual(config.rules.indent, ['error', 4, {SwitchCase: 1}]);
+	t.deepEqual(config.baseConfig.rules.indent, ['error', 4, {SwitchCase: 1}]);
 });
 
 test('buildConfig: semicolon', t => {
 	const config = manager.buildConfig({semicolon: false, nodeVersion: '12'});
-	t.deepEqual(config.rules.semi, ['error', 'never']);
-	t.deepEqual(config.rules['semi-spacing'], ['error', {before: false, after: true}]);
+	t.deepEqual(config.baseConfig.rules.semi, ['error', 'never']);
+	t.deepEqual(config.baseConfig.rules['semi-spacing'], ['error', {before: false, after: true}]);
 });
 
 test('buildConfig: prettier: true', t => {
 	const config = manager.buildConfig({prettier: true, extends: ['xo-react']}, {});
 
-	t.deepEqual(config.plugins, ['prettier']);
+	t.deepEqual(config.baseConfig.plugins, ['prettier']);
 	// Sets the `semi`, `useTabs` and `tabWidth` options in `prettier/prettier` based on the XO `space` and `semicolon` options
 	// Sets `singleQuote`, `trailingComma`, `bracketSpacing` and `jsxBracketSameLine` with XO defaults
-	t.deepEqual(config.rules['prettier/prettier'], ['error', {
+	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: true,
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
@@ -86,20 +102,20 @@ test('buildConfig: prettier: true', t => {
 	// eslint-prettier-config must always be last
 	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'prettier');
 	// Indent rule is not enabled
-	t.is(config.rules.indent, undefined);
+	t.is(config.baseConfig.rules.indent, undefined);
 	// Semi rule is not enabled
-	t.is(config.rules.semi, undefined);
+	t.is(config.baseConfig.rules.semi, undefined);
 	// Semi-spacing is not enabled
-	t.is(config.rules['semi-spacing'], undefined);
+	t.is(config.baseConfig.rules['semi-spacing'], undefined);
 });
 
 test('buildConfig: prettier: true, typescript file', t => {
 	const config = manager.buildConfig({prettier: true, ts: true}, {});
 
-	t.deepEqual(config.plugins, ['prettier']);
+	t.deepEqual(config.baseConfig.plugins, ['prettier']);
 	// Sets the `semi`, `useTabs` and `tabWidth` options in `prettier/prettier` based on the XO `space` and `semicolon` options
 	// Sets `singleQuote`, `trailingComma`, `bracketSpacing` and `jsxBracketSameLine` with XO defaults
-	t.deepEqual(config.rules['prettier/prettier'], ['error', {
+	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: true,
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
@@ -114,18 +130,18 @@ test('buildConfig: prettier: true, typescript file', t => {
 	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 2], 'xo-typescript');
 
 	// Indent rule is not enabled
-	t.is(config.rules.indent, undefined);
+	t.is(config.baseConfig.rules.indent, undefined);
 	// Semi rule is not enabled
-	t.is(config.rules.semi, undefined);
+	t.is(config.baseConfig.rules.semi, undefined);
 	// Semi-spacing is not enabled
-	t.is(config.rules['semi-spacing'], undefined);
+	t.is(config.baseConfig.rules['semi-spacing'], undefined);
 });
 
 test('buildConfig: prettier: true, semicolon: false', t => {
 	const config = manager.buildConfig({prettier: true, semicolon: false}, {});
 
 	// Sets the `semi` options in `prettier/prettier` based on the XO `semicolon` option
-	t.deepEqual(config.rules['prettier/prettier'], ['error', {
+	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: true,
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
@@ -135,18 +151,18 @@ test('buildConfig: prettier: true, semicolon: false', t => {
 		trailingComma: 'none'
 	}]);
 	// Indent rule is not enabled
-	t.is(config.rules.indent, undefined);
+	t.is(config.baseConfig.rules.indent, undefined);
 	// Semi rule is not enabled
-	t.is(config.rules.semi, undefined);
+	t.is(config.baseConfig.rules.semi, undefined);
 	// Semi-spacing is not enabled
-	t.is(config.rules['semi-spacing'], undefined);
+	t.is(config.baseConfig.rules['semi-spacing'], undefined);
 });
 
 test('buildConfig: prettier: true, space: 4', t => {
 	const config = manager.buildConfig({prettier: true, space: 4}, {});
 
 	// Sets `useTabs` and `tabWidth` options in `prettier/prettier` rule based on the XO `space` options
-	t.deepEqual(config.rules['prettier/prettier'], ['error', {
+	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: false,
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
@@ -156,18 +172,18 @@ test('buildConfig: prettier: true, space: 4', t => {
 		trailingComma: 'none'
 	}]);
 	// Indent rule is not enabled
-	t.is(config.rules.indent, undefined);
+	t.is(config.baseConfig.rules.indent, undefined);
 	// Semi rule is not enabled
-	t.is(config.rules.semi, undefined);
+	t.is(config.baseConfig.rules.semi, undefined);
 	// Semi-spacing is not enabled
-	t.is(config.rules['semi-spacing'], undefined);
+	t.is(config.baseConfig.rules['semi-spacing'], undefined);
 });
 
 test('buildConfig: prettier: true, space: true', t => {
 	const config = manager.buildConfig({prettier: true, space: true}, {});
 
 	// Sets `useTabs` and `tabWidth` options in `prettier/prettier` rule based on the XO `space` options
-	t.deepEqual(config.rules['prettier/prettier'], ['error', {
+	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: false,
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
@@ -177,11 +193,11 @@ test('buildConfig: prettier: true, space: true', t => {
 		trailingComma: 'none'
 	}]);
 	// Indent rule is not enabled
-	t.is(config.rules.indent, undefined);
+	t.is(config.baseConfig.rules.indent, undefined);
 	// Semi rule is not enabled
-	t.is(config.rules.semi, undefined);
+	t.is(config.baseConfig.rules.semi, undefined);
 	// Semi-spacing is not enabled
-	t.is(config.rules['semi-spacing'], undefined);
+	t.is(config.baseConfig.rules['semi-spacing'], undefined);
 });
 
 test('buildConfig: merge with prettier config', t => {
@@ -189,70 +205,70 @@ test('buildConfig: merge with prettier config', t => {
 	const config = manager.buildConfig({cwd, prettier: true}, prettierConfig.prettier);
 
 	// Sets the `semi` options in `prettier/prettier` based on the XO `semicolon` option
-	t.deepEqual(config.rules['prettier/prettier'], ['error', prettierConfig.prettier]);
+	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', prettierConfig.prettier]);
 	// Indent rule is not enabled
-	t.is(config.rules.indent, undefined);
+	t.is(config.baseConfig.rules.indent, undefined);
 	// Semi rule is not enabled
-	t.is(config.rules.semi, undefined);
+	t.is(config.baseConfig.rules.semi, undefined);
 	// Semi-spacing is not enabled
-	t.is(config.rules['semi-spacing'], undefined);
+	t.is(config.baseConfig.rules['semi-spacing'], undefined);
 });
 
 test('buildConfig: engines: undefined', t => {
 	const config = manager.buildConfig({});
 
 	// Do not include any Node.js version specific rules
-	t.is(config.rules['prefer-object-spread'], 'off');
-	t.is(config.rules['prefer-rest-params'], 'off');
-	t.is(config.rules['prefer-destructuring'], 'off');
-	t.is(config.rules['promise/prefer-await-to-then'], 'off');
-	t.is(config.rules['unicorn/prefer-flat-map'], 'off');
-	t.is(config.rules['node/prefer-promises/dns'], 'off');
-	t.is(config.rules['node/prefer-promises/fs'], 'off');
-	t.is(config.rules['node/no-unsupported-features/es-builtins'], undefined);
-	t.is(config.rules['node/no-unsupported-features/es-syntax'], undefined);
-	t.is(config.rules['node/no-unsupported-features/node-builtins'], undefined);
+	t.is(config.baseConfig.rules['prefer-object-spread'], 'off');
+	t.is(config.baseConfig.rules['prefer-rest-params'], 'off');
+	t.is(config.baseConfig.rules['prefer-destructuring'], 'off');
+	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], 'off');
+	t.is(config.baseConfig.rules['unicorn/prefer-flat-map'], 'off');
+	t.is(config.baseConfig.rules['node/prefer-promises/dns'], 'off');
+	t.is(config.baseConfig.rules['node/prefer-promises/fs'], 'off');
+	t.is(config.baseConfig.rules['node/no-unsupported-features/es-builtins'], undefined);
+	t.is(config.baseConfig.rules['node/no-unsupported-features/es-syntax'], undefined);
+	t.is(config.baseConfig.rules['node/no-unsupported-features/node-builtins'], undefined);
 });
 
 test('buildConfig: nodeVersion: false', t => {
 	const config = manager.buildConfig({nodeVersion: false});
 
 	// Override all the rules specific to Node.js version
-	t.is(config.rules['prefer-object-spread'], 'off');
-	t.is(config.rules['prefer-rest-params'], 'off');
-	t.is(config.rules['prefer-destructuring'], 'off');
-	t.is(config.rules['promise/prefer-await-to-then'], 'off');
-	t.is(config.rules['unicorn/prefer-flat-map'], 'off');
-	t.is(config.rules['node/prefer-promises/dns'], 'off');
-	t.is(config.rules['node/prefer-promises/fs'], 'off');
+	t.is(config.baseConfig.rules['prefer-object-spread'], 'off');
+	t.is(config.baseConfig.rules['prefer-rest-params'], 'off');
+	t.is(config.baseConfig.rules['prefer-destructuring'], 'off');
+	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], 'off');
+	t.is(config.baseConfig.rules['unicorn/prefer-flat-map'], 'off');
+	t.is(config.baseConfig.rules['node/prefer-promises/dns'], 'off');
+	t.is(config.baseConfig.rules['node/prefer-promises/fs'], 'off');
 });
 
 test('buildConfig: nodeVersion: >=6', t => {
 	const config = manager.buildConfig({nodeVersion: '>=6'});
 
 	// Turn off rule if we support Node.js below 7.6.0
-	t.is(config.rules['promise/prefer-await-to-then'], 'off');
+	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], 'off');
 	// Set node/no-unsupported-features rules with the nodeVersion
-	t.deepEqual(config.rules['node/no-unsupported-features/es-builtins'], ['error', {version: '>=6'}]);
+	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/es-builtins'], ['error', {version: '>=6'}]);
 	t.deepEqual(
-		config.rules['node/no-unsupported-features/es-syntax'],
+		config.baseConfig.rules['node/no-unsupported-features/es-syntax'],
 		['error', {version: '>=6', ignores: ['modules']}]
 	);
-	t.deepEqual(config.rules['node/no-unsupported-features/node-builtins'], ['error', {version: '>=6'}]);
+	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/node-builtins'], ['error', {version: '>=6'}]);
 });
 
 test('buildConfig: nodeVersion: >=8', t => {
 	const config = manager.buildConfig({nodeVersion: '>=8'});
 
 	// Do not turn off rule if we support only Node.js above 7.6.0
-	t.is(config.rules['promise/prefer-await-to-then'], undefined);
+	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], undefined);
 	// Set node/no-unsupported-features rules with the nodeVersion
-	t.deepEqual(config.rules['node/no-unsupported-features/es-builtins'], ['error', {version: '>=8'}]);
+	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/es-builtins'], ['error', {version: '>=8'}]);
 	t.deepEqual(
-		config.rules['node/no-unsupported-features/es-syntax'],
+		config.baseConfig.rules['node/no-unsupported-features/es-syntax'],
 		['error', {version: '>=8', ignores: ['modules']}]
 	);
-	t.deepEqual(config.rules['node/no-unsupported-features/node-builtins'], ['error', {version: '>=8'}]);
+	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/node-builtins'], ['error', {version: '>=8'}]);
 });
 
 test('mergeWithPrettierConfig: use `singleQuote`, `trailingComma`, `bracketSpacing` and `jsxBracketSameLine` from `prettier` config if defined', t => {
@@ -346,7 +362,7 @@ test('mergeWithPrettierConfig: throw error is `space`/`tabWidth` conflicts', t =
 test('buildConfig: rules', t => {
 	const rules = {'object-curly-spacing': ['error', 'always']};
 	const config = manager.buildConfig({rules, nodeVersion: '12'});
-	t.deepEqual(config.rules['object-curly-spacing'], rules['object-curly-spacing']);
+	t.deepEqual(config.baseConfig.rules['object-curly-spacing'], rules['object-curly-spacing']);
 });
 
 test('buildConfig: parser', t => {
@@ -397,20 +413,22 @@ test('buildConfig: webpack option is merged with import/resolver', t => {
 });
 
 test('buildConfig: extends', t => {
-	const config = manager.buildConfig({extends: [
-		'plugin:foo/bar',
-		'eslint-config-foo-bar',
-		'foo-bar-two',
-		'@foobar',
-		'@foobar/eslint-config'
-	]});
+	const config = manager.buildConfig({
+		extends: [
+			'plugin:foo/bar',
+			'eslint-config-foo-bar',
+			'foo-bar-two',
+			'@foobar',
+			'@foobar/eslint-config'
+		]
+	});
 
 	t.deepEqual(config.baseConfig.extends.slice(-5), [
 		'plugin:foo/bar',
 		'cwd/eslint-config-foo-bar',
 		'cwd/eslint-config-foo-bar-two',
-		'@foobar',
-		'@foobar/eslint-config'
+		'cwd/@foobar/eslint-config',
+		'cwd/@foobar/eslint-config'
 	]);
 });
 
@@ -470,9 +488,9 @@ test('mergeWithFileConfig: use parent if closest', t => {
 
 test('mergeWithFileConfig: use parent if child is ignored', t => {
 	const cwd = path.resolve('fixtures', 'nested');
-	const filename = path.resolve(cwd, 'child-ignore', 'file.js');
-	const {options} = manager.mergeWithFileConfig({cwd, filename});
-	const expected = {...parentConfig.xo, extensions: DEFAULT_EXTENSION, ignores: DEFAULT_IGNORES, cwd, filename};
+	const filePath = path.resolve(cwd, 'child-ignore', 'file.js');
+	const {options} = manager.mergeWithFileConfig({cwd, filePath});
+	const expected = {...parentConfig.xo, extensions: DEFAULT_EXTENSION, ignores: DEFAULT_IGNORES, cwd, filePath};
 	t.deepEqual(options, expected);
 });
 
@@ -505,10 +523,10 @@ test('mergeWithFileConfig: XO engine options false supersede package.json\'s', t
 
 test('mergeWithFileConfig: typescript files', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'child');
-	const filename = path.resolve(cwd, 'file.ts');
-	const {options} = manager.mergeWithFileConfig({cwd, filename});
+	const filePath = path.resolve(cwd, 'file.ts');
+	const {options} = manager.mergeWithFileConfig({cwd, filePath});
 	const expected = {
-		filename,
+		filePath,
 		extensions: DEFAULT_EXTENSION,
 		ignores: DEFAULT_IGNORES,
 		cwd,
@@ -525,10 +543,10 @@ test('mergeWithFileConfig: typescript files', async t => {
 
 test('mergeWithFileConfig: tsx files', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'child');
-	const filename = path.resolve(cwd, 'file.tsx');
-	const {options} = manager.mergeWithFileConfig({cwd, filename});
+	const filePath = path.resolve(cwd, 'file.tsx');
+	const {options} = manager.mergeWithFileConfig({cwd, filePath});
 	const expected = {
-		filename,
+		filePath,
 		extensions: DEFAULT_EXTENSION,
 		ignores: DEFAULT_IGNORES,
 		cwd,

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -2,19 +2,15 @@ import path from 'path';
 import test from 'ava';
 import omit from 'lodash/omit';
 import {readJson} from 'fs-extra';
-import proxyquire from 'proxyquire';
 import slash from 'slash';
 import {DEFAULT_EXTENSION, DEFAULT_IGNORES} from '../lib/constants';
 import parentConfig from './fixtures/nested/package.json';
 import childConfig from './fixtures/nested/child/package.json';
 import prettierConfig from './fixtures/prettier/package.json';
 import enginesConfig from './fixtures/engines/package.json';
+import manager from '../lib/options-manager';
 
 process.chdir(__dirname);
-
-const manager = proxyquire('../lib/options-manager', {
-	'resolve-from': (cwd, path) => `cwd/${path}`
-});
 
 test('normalizeOptions: makes all the options plural and arrays', t => {
 	const options = manager.normalizeOptions({
@@ -65,7 +61,7 @@ test('buildConfig: defaults', t => {
 	t.regex(slash(config.cacheLocation), /[\\/]\.cache\/xo-linter\/xo-cache.json[\\/]?$/u);
 	t.is(config.useEslintrc, false);
 	t.is(config.cache, true);
-	t.is(config.baseConfig.extends[0], 'xo');
+	t.true(config.baseConfig.extends[0].includes('eslint-config-xo'));
 });
 
 test('buildConfig: space: true', t => {
@@ -416,19 +412,13 @@ test('buildConfig: extends', t => {
 	const config = manager.buildConfig({
 		extends: [
 			'plugin:foo/bar',
-			'eslint-config-foo-bar',
-			'foo-bar-two',
-			'@foobar',
-			'@foobar/eslint-config'
+			'eslint-config-prettier'
 		]
 	});
 
-	t.deepEqual(config.baseConfig.extends.slice(-5), [
+	t.deepEqual(config.baseConfig.extends.slice(-2), [
 		'plugin:foo/bar',
-		'cwd/eslint-config-foo-bar',
-		'cwd/eslint-config-foo-bar-two',
-		'cwd/@foobar/eslint-config',
-		'cwd/@foobar/eslint-config'
+		path.resolve('../node_modules/eslint-config-prettier/index.js')
 	]);
 });
 

--- a/test/print-config.js
+++ b/test/print-config.js
@@ -13,8 +13,8 @@ const hasPrintConfigGlobal = config => Object.keys(config.globals).includes('pri
 
 test('getConfig', async t => {
 	const filepath = await tempWrite('console.log()\n', 'x.js');
-	const options = {filename: filepath, globals: ['printConfig']};
-	const result = xo.getConfig(options);
+	const options = {filePath: filepath, globals: ['printConfig']};
+	const result = await xo.getConfig(options);
 	t.true(hasUnicornPlugin(result) && hasPrintConfigGlobal(result));
 });
 


### PR DESCRIPTION
Using ESLint's config resolver appears to have fixed something: https://github.com/xojs/xo/pull/534/files#diff-c7ac45885b6a1731e12a1b86ded6b01081581db88a5a625c7b96c222cf05db95L412-R431

Fixes #474