### PR TITLE
Support `xo.config.cjs` and `.xo-config.cjs`

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -120,7 +120,9 @@ const CONFIG_FILES = [
 	`.${MODULE_NAME}-config`,
 	`.${MODULE_NAME}-config.json`,
 	`.${MODULE_NAME}-config.js`,
-	`${MODULE_NAME}.config.js`
+	`.${MODULE_NAME}-config.cjs`,
+	`${MODULE_NAME}.config.js`,
+	`${MODULE_NAME}.config.cjs`
 ];
 
 const TSCONFIG_DEFFAULTS = {

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,14 @@ module.exports = {
 };
 ```
 
+4. For [ECMAScript module (ESM)](https://nodejs.org/api/esm.html) packages with [`"type": "module"`](https://nodejs.org/api/packages.html#packages_type), as a JavaScript module in `.xo-config.cjs` or `xo.config.cjs`:
+
+```js
+module.exports = {
+	space: true
+};
+```
+
 [Globals](https://eslint.org/docs/user-guide/configuring#specifying-globals) and [rules](https://eslint.org/docs/user-guide/configuring#configuring-rules) can be configured inline in files.
 
 ### envs

--- a/test/fixtures/config-files/xo-config_cjs/.xo-config.cjs
+++ b/test/fixtures/config-files/xo-config_cjs/.xo-config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	space: true
+};

--- a/test/fixtures/config-files/xo-config_cjs/file.js
+++ b/test/fixtures/config-files/xo-config_cjs/file.js
@@ -1,0 +1,5 @@
+const object = {
+	a: 1
+};
+
+console.log(object.a);

--- a/test/fixtures/config-files/xo_config_cjs/file.js
+++ b/test/fixtures/config-files/xo_config_cjs/file.js
@@ -1,0 +1,5 @@
+const object = {
+	a: 1
+};
+
+console.log(object.a);

--- a/test/fixtures/config-files/xo_config_cjs/xo.config.cjs
+++ b/test/fixtures/config-files/xo_config_cjs/xo.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	space: true
+};

--- a/test/lint-files.js
+++ b/test/lint-files.js
@@ -278,6 +278,8 @@ async function configType(t, {dir}) {
 configType.title = (_, {type}) => `load config from ${type}`.trim();
 
 test(configType, {type: 'xo.config.js', dir: 'xo-config_js'});
+test(configType, {type: 'xo.config.cjs', dir: 'xo-config_cjs'});
 test(configType, {type: '.xo-config.js', dir: 'xo-config_js'});
+test(configType, {type: '.xo-config.cjs', dir: 'xo-config_cjs'});
 test(configType, {type: '.xo-config.json', dir: 'xo-config_json'});
 test(configType, {type: '.xo-config', dir: 'xo-config'});

--- a/test/lint-text.js
+++ b/test/lint-text.js
@@ -324,6 +324,8 @@ async function configType(t, {dir}) {
 configType.title = (_, {type}) => `load config from ${type}`.trim();
 
 test(configType, {type: 'xo.config.js', dir: 'xo-config_js'});
+test(configType, {type: 'xo.config.cjs', dir: 'xo-config_cjs'});
 test(configType, {type: '.xo-config.js', dir: 'xo-config_js'});
+test(configType, {type: '.xo-config.cjs', dir: 'xo-config_cjs'});
 test(configType, {type: '.xo-config.json', dir: 'xo-config_json'});
 test(configType, {type: '.xo-config', dir: 'xo-config'});


### PR DESCRIPTION
- Fixes `ERR_REQUIRE_ESM` error from `cosmiconfig`.
- Enables using `xo.config.cjs`/`.xo-config.cjs` in ESM packages with `"type": "module"`.

Fixes #468.

See

- https://github.com/xojs/xo/issues/468
- https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

Sample error output; problem fixed by this commit.

```text
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /my-code/.xo-config.js
require() of ES modules is not supported.
require() of /my-code/.xo-config.js from /my-code/node_modules/cosmiconfig/dist/loaders.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename .xo-config.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /my-code/package.json.
```

---

It's a start, but I don't think this fix is a golden bullet for ESM modules depending on `xo`. It fixes small-ish test cases without issue, but mixing ESM/non-ESM code may very well lead to further issues.