### PR TITLE
Prevent the `useEslintrc` option from being used

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -293,6 +293,10 @@ Transform an XO options into ESLint compatible options:
 const buildConfig = (options, prettierOptions) => {
 	options = normalizeOptions(options);
 
+	if (options.useEslintrc) {
+		throw new Error('The `useEslintrc` option is not supported');
+	}
+
 	return flow(
 		buildESLintConfig(options),
 		buildXOConfig(options),

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -461,7 +461,7 @@ test('buildConfig: prevents useEslintrc option', t => {
 	t.throws(() => {
 		manager.buildConfig({
 			useEslintrc: true
-		})
+		});
 	}, {
 		instanceOf: Error,
 		message: 'The `useEslintrc` option is not supported'

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -457,6 +457,15 @@ test('buildConfig: parserOptions', t => {
 	t.is(config.baseConfig.parserOptions.sourceType, 'script');
 });
 
+test('buildConfig: prevents useEslintrc option', t => {
+	t.throws(() => manager.buildConfig({
+		useEslintrc: true
+	}), {
+		instanceOf: Error,
+		message: 'The `useEslintrc` option is not supported'
+	});
+});
+
 test('findApplicableOverrides', t => {
 	const result = manager.findApplicableOverrides('/user/dir/foo.js', [
 		{files: '**/f*.js'},

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -458,9 +458,11 @@ test('buildConfig: parserOptions', t => {
 });
 
 test('buildConfig: prevents useEslintrc option', t => {
-	t.throws(() => manager.buildConfig({
-		useEslintrc: true
-	}), {
+	t.throws(() => {
+		manager.buildConfig({
+			useEslintrc: true
+		})
+	}, {
 		instanceOf: Error,
 		message: 'The `useEslintrc` option is not supported'
 	});


### PR DESCRIPTION
Fixes #338


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#338: Should the `useEslintrc` option be documented?](https://issuehunt.io/repos/40053602/issues/338)
---
</details>
<!-- /Issuehunt content-->