### PR TITLE
Change `trailingComma` option for Prettier to `all`

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -429,7 +429,7 @@ const mergeWithPrettierConfig = (options, prettierOptions) => {
 			singleQuote: true,
 			bracketSpacing: false,
 			jsxBracketSameLine: false,
-			trailingComma: 'none',
+			trailingComma: 'all',
 			tabWidth: normalizeSpaces(options),
 			useTabs: !options.space,
 			semi: options.semicolon !== false,

--- a/readme.md
+++ b/readme.md
@@ -225,7 +225,7 @@ The [Prettier options](https://prettier.io/docs/en/options.html) will be read fr
 - [semi](https://prettier.io/docs/en/options.html#semicolons): based on [semicolon](#semicolon) option
 - [useTabs](https://prettier.io/docs/en/options.html#tabs): based on [space](#space) option
 - [tabWidth](https://prettier.io/docs/en/options.html#tab-width): based on [space](#space) option
-- [trailingComma](https://prettier.io/docs/en/options.html#trailing-commas): `none`
+- [trailingComma](https://prettier.io/docs/en/options.html#trailing-commas): `all`
 - [singleQuote](https://prettier.io/docs/en/options.html#quotes): `true`
 - [bracketSpacing](https://prettier.io/docs/en/options.html#bracket-spacing): `false`
 - [jsxBracketSameLine](https://prettier.io/docs/en/options.html#jsx-brackets): `false`

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -98,7 +98,7 @@ test('buildConfig: prettier: true', t => {
 		semi: true,
 		singleQuote: true,
 		tabWidth: 2,
-		trailingComma: 'none',
+		trailingComma: 'all',
 	}]);
 	// eslint-prettier-config must always be last
 	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'prettier');
@@ -123,7 +123,7 @@ test('buildConfig: prettier: true, typescript file', t => {
 		semi: true,
 		singleQuote: true,
 		tabWidth: 2,
-		trailingComma: 'none',
+		trailingComma: 'all',
 	}]);
 
 	// eslint-prettier-config must always be last
@@ -149,7 +149,7 @@ test('buildConfig: prettier: true, semicolon: false', t => {
 		semi: false,
 		singleQuote: true,
 		tabWidth: 2,
-		trailingComma: 'none',
+		trailingComma: 'all',
 	}]);
 	// Indent rule is not enabled
 	t.is(config.baseConfig.rules.indent, undefined);
@@ -170,7 +170,7 @@ test('buildConfig: prettier: true, space: 4', t => {
 		semi: true,
 		singleQuote: true,
 		tabWidth: 4,
-		trailingComma: 'none',
+		trailingComma: 'all',
 	}]);
 	// Indent rule is not enabled
 	t.is(config.baseConfig.rules.indent, undefined);
@@ -191,7 +191,7 @@ test('buildConfig: prettier: true, space: true', t => {
 		semi: true,
 		singleQuote: true,
 		tabWidth: 2,
-		trailingComma: 'none',
+		trailingComma: 'all',
 	}]);
 	// Indent rule is not enabled
 	t.is(config.baseConfig.rules.indent, undefined);
@@ -275,7 +275,7 @@ test('buildConfig: nodeVersion: >=8', t => {
 test('mergeWithPrettierConfig: use `singleQuote`, `trailingComma`, `bracketSpacing` and `jsxBracketSameLine` from `prettier` config if defined', t => {
 	const prettierOptions = {
 		singleQuote: false,
-		trailingComma: 'all',
+		trailingComma: 'none',
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
 	};
@@ -301,7 +301,7 @@ test('mergeWithPrettierConfig: determine `tabWidth`, `useTabs`, `semi` from xo c
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
 		singleQuote: true,
-		trailingComma: 'none',
+		trailingComma: 'all',
 		...prettierOptions,
 	};
 	t.deepEqual(result, expected);
@@ -318,7 +318,7 @@ test('mergeWithPrettierConfig: determine `tabWidth`, `useTabs`, `semi` from pret
 		bracketSpacing: false,
 		jsxBracketSameLine: false,
 		singleQuote: true,
-		trailingComma: 'none',
+		trailingComma: 'all',
 		...prettierOptions,
 	};
 	t.deepEqual(result, expected);


### PR DESCRIPTION
When running `xo --prettier`, the `trailingComma` is controlled by Prettier, the `comma-dangle` rule will be disabled, 

The `trailingComma: 'all'` behave the same as [the comma-dangle option in `eslint-config-xo`](https://github.com/xojs/eslint-config-xo/blob/main/index.js#L17-L18).

If user want different behaviour, instead of changing `comma-dangle`, user should override Prettier's option.


Fixes #579