### PR TITLE
Fix running `xo --print-config` without a filename

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -173,8 +173,8 @@ if (options.nodeVersion) {
 }
 
 (async () => {
-	if (options.printConfig) {
-		if (input.length > 0) {
+	if (typeof options.printConfig === 'string') {
+		if (input.length > 0 || options.printConfig === '') {
 			console.error('The `--print-config` flag must be used with exactly one filename');
 			process.exit(1);
 		}

--- a/test/cli.js
+++ b/test/cli.js
@@ -190,3 +190,10 @@ test('print-config flag requires a single filename', async t => {
 	);
 	t.is(error.stderr.trim(), 'The `--print-config` flag must be used with exactly one filename');
 });
+
+test('print-config flag without filename', async t => {
+	const error = await t.throwsAsync(() =>
+		main(['--print-config']),
+	);
+	t.is(error.stderr.trim(), 'The `--print-config` flag must be used with exactly one filename');
+});


### PR DESCRIPTION
When running `xo --print-config` without a filename, the CLI actually running lint instead of throw an error.