### PR TITLE
Fix ESLint plugin load error

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import createEsmUtils from 'esm-utils';
 
 const MODULE_DIRECTORY = path.join(createEsmUtils(import.meta).dirname, '..');

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,8 @@
+import path from 'path';
+import createEsmUtils from 'esm-utils';
+
+const MODULE_DIRECTORY = path.join(createEsmUtils(import.meta).dirname, '..');
+
 const DEFAULT_IGNORES = [
 	'**/node_modules/**',
 	'**/bower_components/**',
@@ -140,6 +145,7 @@ const TSCONFIG_DEFAULTS = {
 const CACHE_DIR_NAME = 'xo-linter';
 
 export {
+	MODULE_DIRECTORY,
 	DEFAULT_IGNORES,
 	DEFAULT_EXTENSION,
 	TYPESCRIPT_EXTENSION,

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -31,7 +31,7 @@ import {
 	CACHE_DIR_NAME,
 } from './constants.js';
 
-const {__dirname, json, require} = createEsmUtils(import.meta);
+const {json, require} = createEsmUtils(import.meta);
 const {normalizePackageName} = eslintrc.Legacy.naming;
 const resolveModule = eslintrc.Legacy.ModuleResolver.resolve;
 
@@ -56,8 +56,8 @@ const DEFAULT_CONFIG = {
 	baseConfig: {
 		extends: [
 			resolveLocalConfig('xo'),
-			path.join(__dirname, '../config/overrides.cjs'),
-			path.join(__dirname, '../config/plugins.cjs'),
+			path.join(MODULE_DIRECTORY, 'config/overrides.cjs'),
+			path.join(MODULE_DIRECTORY, 'config/plugins.cjs'),
 		],
 	},
 };

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -18,6 +18,7 @@ import murmur from 'imurmurhash';
 import eslintrc from '@eslint/eslintrc';
 import createEsmUtils from 'esm-utils';
 import {
+	MODULE_DIRECTORY,
 	DEFAULT_IGNORES,
 	DEFAULT_EXTENSION,
 	TYPESCRIPT_EXTENSION,
@@ -289,6 +290,9 @@ const buildESLintConfig = options => config => {
 			...options.parserOptions,
 		};
 	}
+
+	// Resolve plugins from XO root directory
+	config.resolvePluginsRelativeTo = MODULE_DIRECTORY;
 
 	return {
 		...config,


### PR DESCRIPTION
Fixes #546

I think the only problem is,  user can override plugins before, but now can't, ESLint will always load the plugins `xo` installed.

I saw [a comment](https://github.com/xojs/xo/issues/546#issuecomment-863997813) from #546, but I'm not sure what the problem is.