### PR TITLE
Remove `fs-extra` dependency

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -1,7 +1,7 @@
+import {promises as fs} from 'node:fs';
 import process from 'node:process';
 import os from 'node:os';
 import path from 'node:path';
-import fsExtra from 'fs-extra';
 import arrify from 'arrify';
 import {mergeWith, flow, pick} from 'lodash-es';
 import pathExists from 'path-exists';
@@ -128,7 +128,9 @@ const mergeWithFileConfig = async options => {
 
 		options.tsConfigPath = await getTsConfigCachePath([options.filePath], options.tsConfigPath, options.cwd);
 		options.ts = true;
-		await fsExtra.outputJson(options.tsConfigPath, makeTSConfig(tsConfig, tsConfigPath, [options.filePath]));
+		const config = makeTSConfig(tsConfig, tsConfigPath, [options.filePath]);
+		await fs.mkdir(path.dirname(options.tsConfigPath), {recursive: true});
+		await fs.writeFile(options.tsConfigPath, JSON.stringify(config), 'utf-8');
 	}
 
 	return {options, prettierOptions};

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -130,7 +130,7 @@ const mergeWithFileConfig = async options => {
 		options.ts = true;
 		const config = makeTSConfig(tsConfig, tsConfigPath, [options.filePath]);
 		await fs.mkdir(path.dirname(options.tsConfigPath), {recursive: true});
-		await fs.writeFile(options.tsConfigPath, JSON.stringify(config), 'utf-8');
+		await fs.writeFile(options.tsConfigPath, JSON.stringify(config), 'utf8');
 	}
 
 	return {options, prettierOptions};

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
 		"esm-utils": "^1.1.0",
 		"find-cache-dir": "^3.3.1",
 		"find-up": "^5.0.0",
-		"fs-extra": "^10.0.0",
 		"get-stdin": "^9.0.0",
 		"globby": "^12.0.0",
 		"imurmurhash": "^0.1.4",

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -1,14 +1,13 @@
+import {promises as fs} from 'node:fs';
 import process from 'node:process';
 import path from 'node:path';
 import test from 'ava';
 import {omit} from 'lodash-es';
-import fsExtra from 'fs-extra';
 import slash from 'slash';
 import createEsmUtils from 'esm-utils';
 import {DEFAULT_EXTENSION, DEFAULT_IGNORES} from '../lib/constants.js';
 import * as manager from '../lib/options-manager.js';
 
-const {readJson} = fsExtra;
 const {__dirname, require, json} = createEsmUtils(import.meta);
 const parentConfig = json.loadSync('./fixtures/nested/package.json');
 const childConfig = json.loadSync('./fixtures/nested/child/package.json');
@@ -557,7 +556,7 @@ test('mergeWithFileConfig: typescript files', async t => {
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
 	t.deepEqual(omit(options, 'tsConfigPath'), expected);
-	t.deepEqual(await readJson(options.tsConfigPath), {
+	t.deepEqual(JSON.parse(await fs.readFile(options.tsConfigPath, 'utf-8')), {
 		extends: path.resolve(cwd, 'tsconfig.json'),
 		files: [path.resolve(cwd, 'file.ts')],
 		include: [slash(path.resolve(cwd, '**/*.ts')), slash(path.resolve(cwd, '**/*.tsx'))],
@@ -579,7 +578,7 @@ test('mergeWithFileConfig: tsx files', async t => {
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
 	t.deepEqual(omit(options, 'tsConfigPath'), expected);
-	t.deepEqual(await readJson(options.tsConfigPath), {
+	t.deepEqual(JSON.parse(await fs.readFile(options.tsConfigPath, 'utf-8')), {
 		extends: path.resolve(cwd, 'tsconfig.json'),
 		files: [path.resolve(cwd, 'file.tsx')],
 		include: [slash(path.resolve(cwd, '**/*.ts')), slash(path.resolve(cwd, '**/*.tsx'))],

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -578,7 +578,7 @@ test('mergeWithFileConfig: tsx files', async t => {
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
 	t.deepEqual(omit(options, 'tsConfigPath'), expected);
-	t.deepEqual(JSON.parse(await fs.readFile(options.tsConfigPath, 'utf-8')), {
+	t.deepEqual(JSON.parse(await fs.readFile(options.tsConfigPath, 'utf8')), {
 		extends: path.resolve(cwd, 'tsconfig.json'),
 		files: [path.resolve(cwd, 'file.tsx')],
 		include: [slash(path.resolve(cwd, '**/*.ts')), slash(path.resolve(cwd, '**/*.tsx'))],

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -556,7 +556,7 @@ test('mergeWithFileConfig: typescript files', async t => {
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
 	t.deepEqual(omit(options, 'tsConfigPath'), expected);
-	t.deepEqual(JSON.parse(await fs.readFile(options.tsConfigPath, 'utf-8')), {
+	t.deepEqual(JSON.parse(await fs.readFile(options.tsConfigPath, 'utf8')), {
 		extends: path.resolve(cwd, 'tsconfig.json'),
 		files: [path.resolve(cwd, 'file.ts')],
 		include: [slash(path.resolve(cwd, '**/*.ts')), slash(path.resolve(cwd, '**/*.tsx'))],


### PR DESCRIPTION
The usage of `fs-extra` is only related to reading/writing JSON currently, then they can be replaced with some combinations of native modules to reduce the dependency.