### PR TITLE
Remove the unused "debug" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
 		"@typescript-eslint/parser": "^4.29.0",
 		"arrify": "^3.0.0",
 		"cosmiconfig": "^7.0.0",
-		"debug": "^4.3.2",
 		"define-lazy-prop": "^3.0.0",
 		"eslint": "^7.32.0",
 		"eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
I couldn't find any reference to the dependency so it looks like it's unused.