### PR TITLE
Replace Prettier's `jsxBracketSameLine` option with `bracketSameLine`

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -424,7 +424,7 @@ const mergeWithPrettierConfig = (options, prettierOptions) => {
 		{
 			singleQuote: true,
 			bracketSpacing: false,
-			jsxBracketSameLine: false,
+			bracketSameLine: false,
 			trailingComma: 'all',
 			tabWidth: normalizeSpaces(options),
 			useTabs: !options.space,

--- a/readme.md
+++ b/readme.md
@@ -228,7 +228,7 @@ The [Prettier options](https://prettier.io/docs/en/options.html) will be read fr
 - [trailingComma](https://prettier.io/docs/en/options.html#trailing-commas): `all`
 - [singleQuote](https://prettier.io/docs/en/options.html#quotes): `true`
 - [bracketSpacing](https://prettier.io/docs/en/options.html#bracket-spacing): `false`
-- [jsxBracketSameLine](https://prettier.io/docs/en/options.html#jsx-brackets): `false`
+- [bracketSameLine](https://prettier.io/docs/en/options.html#bracket-line): `false`
 
 If contradicting options are set for both Prettier and XO an error will be thrown.
 

--- a/test/fixtures/prettier/package.json
+++ b/test/fixtures/prettier/package.json
@@ -4,7 +4,7 @@
 		"semi": false,
 		"tabWidth": 4,
 		"bracketSpacing": false,
-		"jsxBracketSameLine": false,
+		"bracketSameLine": false,
 		"singleQuote": false,
 		"trailingComma": "all"
 	}

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -89,11 +89,11 @@ test('buildConfig: prettier: true', t => {
 
 	t.deepEqual(config.baseConfig.plugins, ['prettier']);
 	// Sets the `semi`, `useTabs` and `tabWidth` options in `prettier/prettier` based on the XO `space` and `semicolon` options
-	// Sets `singleQuote`, `trailingComma`, `bracketSpacing` and `jsxBracketSameLine` with XO defaults
+	// Sets `singleQuote`, `trailingComma`, `bracketSpacing` and `bracketSameLine` with XO defaults
 	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: true,
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 		semi: true,
 		singleQuote: true,
 		tabWidth: 2,
@@ -114,11 +114,11 @@ test('buildConfig: prettier: true, typescript file', t => {
 
 	t.deepEqual(config.baseConfig.plugins, ['prettier']);
 	// Sets the `semi`, `useTabs` and `tabWidth` options in `prettier/prettier` based on the XO `space` and `semicolon` options
-	// Sets `singleQuote`, `trailingComma`, `bracketSpacing` and `jsxBracketSameLine` with XO defaults
+	// Sets `singleQuote`, `trailingComma`, `bracketSpacing` and `bracketSameLine` with XO defaults
 	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: true,
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 		semi: true,
 		singleQuote: true,
 		tabWidth: 2,
@@ -144,7 +144,7 @@ test('buildConfig: prettier: true, semicolon: false', t => {
 	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: true,
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 		semi: false,
 		singleQuote: true,
 		tabWidth: 2,
@@ -165,7 +165,7 @@ test('buildConfig: prettier: true, space: 4', t => {
 	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: false,
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 		semi: true,
 		singleQuote: true,
 		tabWidth: 4,
@@ -186,7 +186,7 @@ test('buildConfig: prettier: true, space: true', t => {
 	t.deepEqual(config.baseConfig.rules['prettier/prettier'], ['error', {
 		useTabs: false,
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 		semi: true,
 		singleQuote: true,
 		tabWidth: 2,
@@ -271,12 +271,12 @@ test('buildConfig: nodeVersion: >=8', t => {
 	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/node-builtins'], ['error', {version: '>=8'}]);
 });
 
-test('mergeWithPrettierConfig: use `singleQuote`, `trailingComma`, `bracketSpacing` and `jsxBracketSameLine` from `prettier` config if defined', t => {
+test('mergeWithPrettierConfig: use `singleQuote`, `trailingComma`, `bracketSpacing` and `bracketSameLine` from `prettier` config if defined', t => {
 	const prettierOptions = {
 		singleQuote: false,
 		trailingComma: 'none',
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 	};
 	const result = manager.mergeWithPrettierConfig({}, prettierOptions);
 	const expected = {
@@ -298,7 +298,7 @@ test('mergeWithPrettierConfig: determine `tabWidth`, `useTabs`, `semi` from xo c
 	const result = manager.mergeWithPrettierConfig({space: 4, semicolon: false}, {});
 	const expected = {
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 		singleQuote: true,
 		trailingComma: 'all',
 		...prettierOptions,
@@ -315,7 +315,7 @@ test('mergeWithPrettierConfig: determine `tabWidth`, `useTabs`, `semi` from pret
 	const result = manager.mergeWithPrettierConfig({}, prettierOptions);
 	const expected = {
 		bracketSpacing: false,
-		jsxBracketSameLine: false,
+		bracketSameLine: false,
 		singleQuote: true,
 		trailingComma: 'all',
 		...prettierOptions,


### PR DESCRIPTION
`jsxBracketSameLine` was deprecated in prettier 2.4.0.