### PR TITLE
Clarify prettier defaulting behavior

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,14 +221,23 @@ Default: `false`
 
 Format code with [Prettier](https://github.com/prettier/prettier).
 
-The [Prettier options](https://prettier.io/docs/en/options.html) will be read from the [Prettier config](https://prettier.io/docs/en/configuration.html) and if **not set** will be determined as follow:
+[Prettier options](https://prettier.io/docs/en/options.html) will be based on your [Prettier config](https://prettier.io/docs/en/configuration.html). XO will then **_merge_** your options with it's own defaults:
 - [semi](https://prettier.io/docs/en/options.html#semicolons): based on [semicolon](#semicolon) option
 - [useTabs](https://prettier.io/docs/en/options.html#tabs): based on [space](#space) option
 - [tabWidth](https://prettier.io/docs/en/options.html#tab-width): based on [space](#space) option
 - [trailingComma](https://prettier.io/docs/en/options.html#trailing-commas): `all`
 - [singleQuote](https://prettier.io/docs/en/options.html#quotes): `true`
 - [bracketSpacing](https://prettier.io/docs/en/options.html#bracket-spacing): `false`
-- [bracketSameLine](https://prettier.io/docs/en/options.html#bracket-line): `false`
+
+To stick with Prettier's defaults, add this to your prettier config:
+```js
+module.exports = {
+  // Asserting prettier defaults here tells XO to not add in it's own defaults:
+  trailingComma: 'es5',
+  singleQuote: false,
+  bracketSpacing: true,
+}
+```
 
 If contradicting options are set for both Prettier and XO an error will be thrown.
 


### PR DESCRIPTION
This definitely sent me down a rabbit hole: #614

TODO:
1. Cleanup source for `bracketSameLine`. XO Does not need to set it to `false`, since that is prettier's current default. (I'm assuming it was different in the past).
2. Verify this actually works, check when errors are actually thrown
