### PR TITLE
Rename allowList/denyList in `prevent-abbreviations`

### DIFF
--- a/config/plugins.cjs
+++ b/config/plugins.cjs
@@ -44,7 +44,7 @@ module.exports = {
 				replacements: {
 					// https://thenextweb.com/dd/2020/07/13/linux-kernel-will-no-longer-use-terms-blacklist-and-slave/
 					whitelist: {
-						allow: true,
+						include: true,
 					},
 					blacklist: {
 						exclude: true,

--- a/config/plugins.cjs
+++ b/config/plugins.cjs
@@ -44,10 +44,10 @@ module.exports = {
 				replacements: {
 					// https://thenextweb.com/dd/2020/07/13/linux-kernel-will-no-longer-use-terms-blacklist-and-slave/
 					whitelist: {
-						allowList: true,
+						allow: true,
 					},
 					blacklist: {
-						denyList: true,
+						exclude: true,
 					},
 					master: {
 						main: true,


### PR DESCRIPTION
Arrays don't necessarily need to be named `list`. These lists are can just be named allow/allowed/include or exclude/except/exclusions. `deny` itself feels kinda awkward too because it usually applies to "access" only, not other kinds of generic exclusions lists.