### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,29 +52,29 @@
 		"typescript"
 	],
 	"dependencies": {
-		"@eslint/eslintrc": "^1.0.1",
-		"@typescript-eslint/eslint-plugin": "^4.32.0",
-		"@typescript-eslint/parser": "^4.32.0",
+		"@eslint/eslintrc": "^1.0.3",
+		"@typescript-eslint/eslint-plugin": "^5.1.0",
+		"@typescript-eslint/parser": "^5.1.0",
 		"arrify": "^3.0.0",
 		"cosmiconfig": "^7.0.1",
 		"define-lazy-prop": "^3.0.0",
-		"eslint": "^7.32.0",
+		"eslint": "^8.0.1",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-config-xo": "^0.39.0",
-		"eslint-config-xo-typescript": "^0.45.0",
+		"eslint-config-xo-typescript": "^0.45.2",
 		"eslint-formatter-pretty": "^4.1.0",
-		"eslint-import-resolver-webpack": "^0.13.1",
-		"eslint-plugin-ava": "^13.0.0",
+		"eslint-import-resolver-webpack": "^0.13.2",
+		"eslint-plugin-ava": "^13.1.0",
 		"eslint-plugin-eslint-comments": "^3.2.0",
-		"eslint-plugin-import": "^2.24.2",
+		"eslint-plugin-import": "^2.25.2",
 		"eslint-plugin-no-use-extend-native": "^0.5.0",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-prettier": "^4.0.0",
-		"eslint-plugin-promise": "^5.1.0",
-		"eslint-plugin-unicorn": "^36.0.0",
+		"eslint-plugin-promise": "^5.1.1",
+		"eslint-plugin-unicorn": "^37.0.1",
 		"esm-utils": "^2.0.0",
 		"find-cache-dir": "^3.3.2",
-		"find-up": "^6.1.0",
+		"find-up": "^6.2.0",
 		"get-stdin": "^9.0.0",
 		"globby": "^12.0.2",
 		"imurmurhash": "^0.1.4",
@@ -88,7 +88,7 @@
 		"semver": "^7.3.5",
 		"slash": "^4.0.0",
 		"to-absolute-glob": "^2.0.2",
-		"typescript": "^4.4.3"
+		"typescript": "^4.4.4"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",
@@ -99,7 +99,7 @@
 		"nyc": "^15.1.0",
 		"proxyquire": "^2.1.3",
 		"temp-write": "^5.0.0",
-		"webpack": "^5.56.0"
+		"webpack": "^5.59.1"
 	},
 	"xo": {
 		"ignores": [


### PR DESCRIPTION
It seems there is no code change needed, but there are still warnings when installing with `yarn`

```text
warning " > eslint-plugin-promise@5.1.1" has incorrect peer dependency "eslint@^7.0.0".
warning " > eslint-plugin-react@7.26.1" has incorrect peer dependency "eslint@^3 || ^4 || ^5 || ^6 || ^7".
warning " > eslint-plugin-react-hooks@4.2.0" has incorrect peer dependency "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0".
```


Fixes #618