### PR TITLE
Enforce extensions on TypeScript files as well

### DIFF
--- a/config/plugins.cjs
+++ b/config/plugins.cjs
@@ -193,12 +193,7 @@ module.exports = {
 			'error',
 			'always',
 			{
-				ignorePackages: true,
-				// TypeScript doesn't yet support using extensions and fails with error TS2691.
-				pattern: {
-					ts: 'never',
-					tsx: 'never',
-				},
+				ignorePackages: true
 			},
 		],
 		'import/first': 'error',

--- a/config/plugins.cjs
+++ b/config/plugins.cjs
@@ -193,7 +193,7 @@ module.exports = {
 			'error',
 			'always',
 			{
-				ignorePackages: true
+				ignorePackages: true,
 			},
 		],
 		'import/first': 'error',


### PR DESCRIPTION
I think this config should be dropped. Reasons:

- it actually "breaks" the rule for .ts/tsx files because it allows them to be imported without extension

	1. create `file.ts`
	2. `import './file'` in `another.ts`
	3. No errors! 😰 

- it duplicates TypeScript’s own error, but with a worse message:

	<img width="638" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/143395326-c82810ac-28c5-4859-abfd-e5af443307f4.png">

