### PR TITLE
feat!: switch to eslint-plugin-node's maintained fork

### DIFF
--- a/config/plugins.cjs
+++ b/config/plugins.cjs
@@ -17,7 +17,7 @@ module.exports = {
 		// Disabled as the plugin doesn't support ESLint 8 yet.
 		// 'promise',
 		'import',
-		'node',
+		'n', // eslint-plugin-node's successor
 		'eslint-comments',
 	],
 	extends: [
@@ -264,17 +264,17 @@ module.exports = {
 		],
 
 		// Redundant with `import/no-extraneous-dependencies`.
-		// 'node/no-extraneous-import': 'error',
-		// 'node/no-extraneous-require': 'error',
+		// 'n/no-extraneous-import': 'error',
+		// 'n/no-extraneous-require': 'error',
 
 		// Redundant with `import/no-unresolved`.
-		// 'node/no-missing-import': 'error', // This rule is also buggy and doesn't support `node:`.
-		// 'node/no-missing-require': 'error',
+		// 'n/no-missing-import': 'error', // This rule is also buggy and doesn't support `node:`.
+		// 'n/no-missing-require': 'error',
 
-		'node/no-unpublished-bin': 'error',
+		'n/no-unpublished-bin': 'error',
 
 		// We have this enabled in addition to `import/extensions` as this one has an auto-fix.
-		'node/file-extension-in-import': [
+		'n/file-extension-in-import': [
 			'error',
 			'always',
 			{
@@ -283,19 +283,19 @@ module.exports = {
 				'.tsx': 'never',
 			},
 		],
-		'node/no-mixed-requires': [
+		'n/no-mixed-requires': [
 			'error',
 			{
 				grouping: true,
 				allowCall: true,
 			},
 		],
-		'node/no-new-require': 'error',
-		'node/no-path-concat': 'error',
+		'n/no-new-require': 'error',
+		'n/no-path-concat': 'error',
 
 		// Disabled because they're too annoying, see:
 		// https://github.com/mysticatea/eslint-plugin-node/issues/105
-		// 'node/no-unpublished-import': [
+		// 'n/no-unpublished-import': [
 		// 	'error',
 		// 	{
 		// 		allowModules: [
@@ -304,7 +304,7 @@ module.exports = {
 		// 		]
 		// 	}
 		// ],
-		// 'node/no-unpublished-require': [
+		// 'n/no-unpublished-require': [
 		// 	'error',
 		// 	{
 		// 		allowModules: [
@@ -314,42 +314,42 @@ module.exports = {
 		// 	}
 		// ],
 
-		'node/process-exit-as-throw': 'error',
+		'n/process-exit-as-throw': 'error',
 
 		// Disabled as the rule doesn't exclude scripts executed with `node` but not referenced in 'bin'. See https://github.com/mysticatea/eslint-plugin-node/issues/96
-		// 'node/shebang': 'error',
+		// 'n/shebang': 'error',
 
-		'node/no-deprecated-api': 'error',
-		'node/prefer-global/buffer': [
+		'n/no-deprecated-api': 'error',
+		'n/prefer-global/buffer': [
 			'error',
 			'never',
 		],
-		'node/prefer-global/console': [
+		'n/prefer-global/console': [
 			'error',
 			'always',
 		],
-		'node/prefer-global/process': [
+		'n/prefer-global/process': [
 			'error',
 			'never',
 		],
-		'node/prefer-global/text-decoder': [
+		'n/prefer-global/text-decoder': [
 			'error',
 			'always',
 		],
-		'node/prefer-global/text-encoder': [
+		'n/prefer-global/text-encoder': [
 			'error',
 			'always',
 		],
-		'node/prefer-global/url-search-params': [
+		'n/prefer-global/url-search-params': [
 			'error',
 			'always',
 		],
-		'node/prefer-global/url': [
+		'n/prefer-global/url': [
 			'error',
 			'always',
 		],
-		'node/prefer-promises/dns': 'error',
-		'node/prefer-promises/fs': 'error',
+		'n/prefer-promises/dns': 'error',
+		'n/prefer-promises/fs': 'error',
 		'eslint-comments/disable-enable-pair': [
 			'error',
 			{

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -77,10 +77,10 @@ const ENGINE_RULES = {
 	'prefer-object-spread': {
 		'8.3.0': 'off',
 	},
-	'node/prefer-global/url-search-params': {
+	'n/prefer-global/url-search-params': {
 		'10.0.0': 'off',
 	},
-	'node/prefer-global/url': {
+	'n/prefer-global/url': {
 		'10.0.0': 'off',
 	},
 	'no-useless-catch': {
@@ -89,19 +89,19 @@ const ENGINE_RULES = {
 	'prefer-named-capture-group': {
 		'10.0.0': 'off',
 	},
-	'node/prefer-global/text-encoder': {
+	'n/prefer-global/text-encoder': {
 		'11.0.0': 'off',
 	},
-	'node/prefer-global/text-decoder': {
+	'n/prefer-global/text-decoder': {
 		'11.0.0': 'off',
 	},
 	'unicorn/prefer-flat-map': {
 		'11.0.0': 'off',
 	},
-	'node/prefer-promises/dns': {
+	'n/prefer-promises/dns': {
 		'11.14.0': 'off',
 	},
-	'node/prefer-promises/fs': {
+	'n/prefer-promises/fs': {
 		'11.14.0': 'off',
 	},
 };

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -327,9 +327,9 @@ const buildXOConfig = options => config => {
 	}
 
 	if (options.nodeVersion) {
-		config.baseConfig.rules['node/no-unsupported-features/es-builtins'] = ['error', {version: options.nodeVersion}];
-		config.baseConfig.rules['node/no-unsupported-features/es-syntax'] = ['error', {version: options.nodeVersion, ignores: ['modules']}];
-		config.baseConfig.rules['node/no-unsupported-features/node-builtins'] = ['error', {version: options.nodeVersion}];
+		config.baseConfig.rules['n/no-unsupported-features/es-builtins'] = ['error', {version: options.nodeVersion}];
+		config.baseConfig.rules['n/no-unsupported-features/es-syntax'] = ['error', {version: options.nodeVersion, ignores: ['modules']}];
+		config.baseConfig.rules['n/no-unsupported-features/node-builtins'] = ['error', {version: options.nodeVersion}];
 	}
 
 	if (options.space && !options.prettier) {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"eslint-plugin-ava": "^13.2.0",
 		"eslint-plugin-eslint-comments": "^3.2.0",
 		"eslint-plugin-import": "^2.26.0",
+		"eslint-plugin-n": "^15.1.0",
 		"eslint-plugin-no-use-extend-native": "^0.5.0",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-prettier": "^4.0.0",
@@ -125,5 +126,10 @@
 			"text",
 			"lcov"
 		]
-	}
+	},
+	"bundleDependencies": [
+		"@typescript-eslint/eslint-plugin",
+		"@typescript-eslint/parser",
+		"eslint-config-xo-typescript"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
 		"eslint-plugin-import": "^2.26.0",
 		"eslint-plugin-n": "^15.1.0",
 		"eslint-plugin-no-use-extend-native": "^0.5.0",
-		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-prettier": "^4.0.0",
 		"eslint-plugin-unicorn": "^42.0.0",
 		"esm-utils": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -125,10 +125,5 @@
 			"text",
 			"lcov"
 		]
-	},
-	"bundleDependencies": [
-		"@typescript-eslint/eslint-plugin",
-		"@typescript-eslint/parser",
-		"eslint-config-xo-typescript"
-	]
+	}
 }

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -222,11 +222,11 @@ test('buildConfig: engines: undefined', t => {
 	t.is(config.baseConfig.rules['prefer-destructuring'], 'off');
 	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], 'off');
 	t.is(config.baseConfig.rules['unicorn/prefer-flat-map'], 'off');
-	t.is(config.baseConfig.rules['node/prefer-promises/dns'], 'off');
-	t.is(config.baseConfig.rules['node/prefer-promises/fs'], 'off');
-	t.is(config.baseConfig.rules['node/no-unsupported-features/es-builtins'], undefined);
-	t.is(config.baseConfig.rules['node/no-unsupported-features/es-syntax'], undefined);
-	t.is(config.baseConfig.rules['node/no-unsupported-features/node-builtins'], undefined);
+	t.is(config.baseConfig.rules['n/prefer-promises/dns'], 'off');
+	t.is(config.baseConfig.rules['n/prefer-promises/fs'], 'off');
+	t.is(config.baseConfig.rules['n/no-unsupported-features/es-builtins'], undefined);
+	t.is(config.baseConfig.rules['n/no-unsupported-features/es-syntax'], undefined);
+	t.is(config.baseConfig.rules['n/no-unsupported-features/node-builtins'], undefined);
 });
 
 test('buildConfig: nodeVersion: false', t => {
@@ -238,8 +238,8 @@ test('buildConfig: nodeVersion: false', t => {
 	t.is(config.baseConfig.rules['prefer-destructuring'], 'off');
 	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], 'off');
 	t.is(config.baseConfig.rules['unicorn/prefer-flat-map'], 'off');
-	t.is(config.baseConfig.rules['node/prefer-promises/dns'], 'off');
-	t.is(config.baseConfig.rules['node/prefer-promises/fs'], 'off');
+	t.is(config.baseConfig.rules['n/prefer-promises/dns'], 'off');
+	t.is(config.baseConfig.rules['n/prefer-promises/fs'], 'off');
 });
 
 test('buildConfig: nodeVersion: >=6', t => {
@@ -247,13 +247,13 @@ test('buildConfig: nodeVersion: >=6', t => {
 
 	// Turn off rule if we support Node.js below 7.6.0
 	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], 'off');
-	// Set node/no-unsupported-features rules with the nodeVersion
-	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/es-builtins'], ['error', {version: '>=6'}]);
+	// Set n/no-unsupported-features rules with the nodeVersion
+	t.deepEqual(config.baseConfig.rules['n/no-unsupported-features/es-builtins'], ['error', {version: '>=6'}]);
 	t.deepEqual(
-		config.baseConfig.rules['node/no-unsupported-features/es-syntax'],
+		config.baseConfig.rules['n/no-unsupported-features/es-syntax'],
 		['error', {version: '>=6', ignores: ['modules']}],
 	);
-	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/node-builtins'], ['error', {version: '>=6'}]);
+	t.deepEqual(config.baseConfig.rules['n/no-unsupported-features/node-builtins'], ['error', {version: '>=6'}]);
 });
 
 test('buildConfig: nodeVersion: >=8', t => {
@@ -261,13 +261,13 @@ test('buildConfig: nodeVersion: >=8', t => {
 
 	// Do not turn off rule if we support only Node.js above 7.6.0
 	t.is(config.baseConfig.rules['promise/prefer-await-to-then'], undefined);
-	// Set node/no-unsupported-features rules with the nodeVersion
-	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/es-builtins'], ['error', {version: '>=8'}]);
+	// Set n/no-unsupported-features rules with the nodeVersion
+	t.deepEqual(config.baseConfig.rules['n/no-unsupported-features/es-builtins'], ['error', {version: '>=8'}]);
 	t.deepEqual(
-		config.baseConfig.rules['node/no-unsupported-features/es-syntax'],
+		config.baseConfig.rules['n/no-unsupported-features/es-syntax'],
 		['error', {version: '>=8', ignores: ['modules']}],
 	);
-	t.deepEqual(config.baseConfig.rules['node/no-unsupported-features/node-builtins'], ['error', {version: '>=8'}]);
+	t.deepEqual(config.baseConfig.rules['n/no-unsupported-features/node-builtins'], ['error', {version: '>=8'}]);
 });
 
 test('mergeWithPrettierConfig: use `singleQuote`, `trailingComma`, `bracketSpacing` and `bracketSameLine` from `prettier` config if defined', t => {


### PR DESCRIPTION
move to eslint-plugin-n: https://www.npmjs.com/package/eslint-plugin-n. as the original one is no longer actively maintained(last version was released ~2y ago).

the fork has been adopted by standard.