### PR TITLE
Add `--fix-dry-run` option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,7 @@ const cli = meow(`
 
 	Options
 	  --fix             Automagically fix issues
+	  --fix-dry-run     Automatically fix problems without saving the changes to the file system
 	  --reporter        Reporter to use
 	  --env             Environment preset  [Can be set multiple times]
 	  --global          Global variable  [Can be set multiple times]
@@ -51,6 +52,9 @@ const cli = meow(`
 	booleanDefault: undefined,
 	flags: {
 		fix: {
+			type: 'boolean',
+		},
+		fixDryRun: {
 			type: 'boolean',
 		},
 		reporter: {

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -309,6 +309,10 @@ const buildESLintConfig = options => config => {
 		};
 	}
 
+	// eslint doesn't expose `fixDryRun` option in programmatic API.
+	// Instead of using `fixDryRun` itself, the option is internally translated to `fix` option in eslint's CLI module.
+	// (Ref: https://github.com/eslint/eslint/blob/901ce0f1e32ea1e9e10ce4d8b37c0d750007a3c5/lib/cli.js#L96)
+	// xo also could handle this in the same way.
 	if (options.fixDryRun) {
 		config.fix = true;
 	}

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -308,6 +308,10 @@ const buildESLintConfig = options => config => {
 			...options.parserOptions,
 		};
 	}
+	
+	if (options.fixDryRun) {
+		config.fix = true;			
+	}
 
 	return {
 		...config,

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -309,10 +309,9 @@ const buildESLintConfig = options => config => {
 		};
 	}
 
-	// eslint doesn't expose `fixDryRun` option in programmatic API.
-	// Instead of using `fixDryRun` itself, the option is internally translated to `fix` option in eslint's CLI module.
-	// (Ref: https://github.com/eslint/eslint/blob/901ce0f1e32ea1e9e10ce4d8b37c0d750007a3c5/lib/cli.js#L96)
-	// xo also could handle this in the same way.
+	// ESLint does not expose a `fixDryRun` option in the programmatic API.
+	// Instead of using `fixDryRun` itself, the option is internally translated to `fix` option in ESLint's CLI module.
+	// https://github.com/eslint/eslint/blob/901ce0f1e32ea1e9e10ce4d8b37c0d750007a3c5/lib/cli.js#L96
 	if (options.fixDryRun) {
 		config.fix = true;
 	}

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -308,9 +308,9 @@ const buildESLintConfig = options => config => {
 			...options.parserOptions,
 		};
 	}
-	
+
 	if (options.fixDryRun) {
-		config.fix = true;			
+		config.fix = true;
 	}
 
 	return {

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -310,8 +310,8 @@ const buildESLintConfig = options => config => {
 	}
 
 	// ESLint does not expose a `fixDryRun` option in the programmatic API.
-	// Instead of using `fixDryRun` itself, the option is internally translated to `fix` option in ESLint's CLI module.
-	// https://github.com/eslint/eslint/blob/901ce0f1e32ea1e9e10ce4d8b37c0d750007a3c5/lib/cli.js#L96
+	// Since ESLint programmatic API's `fix` option does not mean saving the changes to the file system, unlike ESLint CLI's one.
+	// So, the dry-run can be implemented by passing `fix` option to ESLint's API, and not calling `outputFixes`.
 	if (options.fixDryRun) {
 		config.fix = true;
 	}

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ $ xo --help
 
   Options
     --fix             Automagically fix issues
+    --fix-dry-run     Automatically fix problems without saving the changes to the file system
     --reporter        Reporter to use
     --env             Environment preset  [Can be set multiple times]
     --global          Global variable  [Can be set multiple times]

--- a/test/cli.js
+++ b/test/cli.js
@@ -26,6 +26,13 @@ test('fix option with stdin', async t => {
 	t.is(stdout, 'console.log();');
 });
 
+test('fix-dry-run option', async t => {
+	const {stdout} = await main(['--fix-dry-run', '--stdin', '--reporter', 'json'], {
+		input: 'console.log()',
+	});
+	t.is(JSON.parse(stdout)[0].output, 'console.log();\n');
+});
+
 test('stdin-filename option with stdin', async t => {
 	const {stdout} = await main(['--stdin', '--stdin-filename=unicorn-file'], {
 		input: 'console.log()\n',

--- a/test/cli.js
+++ b/test/cli.js
@@ -26,7 +26,15 @@ test('fix option with stdin', async t => {
 	t.is(stdout, 'console.log();');
 });
 
-test('fix-dry-run option', async t => {
+test('fix-dry-run option should not overwrite source file', async t => {
+	const cwd = await fs.promises.mkdtemp(path.join(__dirname, './temp/'));
+	const filepath = path.join(cwd, 'x.js');
+	await fs.promises.writeFile(filepath, 'console.log()\n');
+	await main(['--fix-dry-run', filepath], {cwd});
+	t.is(fs.readFileSync(filepath, 'utf8'), 'console.log()\n');
+});
+
+test('fix-dry-run option with stdin', async t => {
 	const {stdout} = await main(['--fix-dry-run', '--stdin', '--reporter', 'json'], {
 		input: 'console.log()',
 	});


### PR DESCRIPTION
Fixes #663.

Eslint doesn't expose `fixDryRun` option in programmatic API. 
`fixDryRun` is [internally translated to `fix` option](https://github.com/eslint/eslint/blob/main/lib/cli.js#L96) and don't call `ESLint.outputFixes`.
(Ref: https://github.com/eslint/eslint/discussions/15877)

So I think `xo` could handle this option similarly.
`fixDryRun` is translated to `fix` option before passing to ESLint constructor, and `xo.outputFixes` would not be called since 
the `fix` option is false.