### PR TITLE
chore: bump eslint-plugin-n (import expressions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"eslint-plugin-ava": "^13.2.0",
 		"eslint-plugin-eslint-comments": "^3.2.0",
 		"eslint-plugin-import": "^2.26.0",
-		"eslint-plugin-n": "^15.1.0",
+		"eslint-plugin-n": "^15.2.1",
 		"eslint-plugin-no-use-extend-native": "^0.5.0",
 		"eslint-plugin-prettier": "^4.0.0",
 		"eslint-plugin-unicorn": "^42.0.0",


### PR DESCRIPTION
Per https://github.com/mysticatea/eslint-plugin-node/issues/250#issuecomment-1077640484 and #660 we need to bump this by minor version and bump the patch as well to latest.  This commit achieves that.  Once merged, please publish a new version to npm of `xo`.  Thanks!