### PR TITLE
Specify webpack as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,14 @@
 		"temp-write": "^5.0.0",
 		"webpack": "^5.73.0"
 	},
+	"peerDependencies": { 
+		"webpack": ">=1.11.0"
+	},
+	"peerDependenciesMeta": {
+		"webpack": {
+			"optional": true
+		}
+	},
 	"xo": {
 		"ignores": [
 			"test/fixtures",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"temp-write": "^5.0.0",
 		"webpack": "^5.73.0"
 	},
-	"peerDependencies": { 
+	"peerDependencies": {
 		"webpack": ">=1.11.0"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
This is basically the same PR as https://github.com/vuejs/vue-loader/pull/1853 + https://github.com/vuejs/vue-loader/commit/089473af97077b8e14b3feff48d32d2733ad792c

See https://yarnpkg.com/configuration/yarnrc#packageExtensions on why this should be fixed here.

Fixes #449