### PR TITLE
Relative 'extends' no longer error out in the XO VS Code extension, nor if running XO from a different folder

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -413,7 +413,7 @@ const buildExtendsConfig = options => config => {
 	if (options.extends && options.extends.length > 0) {
 		const configs = options.extends.map(name => {
 			// Don't do anything if it's a filepath
-			if (existsSync(name)) {
+			if (existsSync(path.resolve(options.cwd || process.cwd(), name))) {
 				return name;
 			}
 


### PR DESCRIPTION
Relative 'extends' no longer error out in the XO VS Code extension, nor if running XO from a different folder.

Fixes xojs/xo#685

Addressed issue by altering the existsSync call. By default [node:fs resolves paths relative to the directory returned by process.cwd](https://nodejs.org/api/fs.html#string-paths). For the XO VS Code extension, process.cwd() references the VS Code program folder.