### PR TITLE
Fix windows directory  separator

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -16,6 +16,7 @@ import stringify from 'json-stable-stringify-without-jsonify';
 import {Legacy} from '@eslint/eslintrc';
 import createEsmUtils from 'esm-utils';
 import MurmurHash3 from 'imurmurhash';
+import slash from 'slash';
 import {
 	DEFAULT_IGNORES,
 	DEFAULT_EXTENSION,
@@ -174,6 +175,10 @@ const handleTSConfig = async options => {
 		options.tsConfig = searchResults.config;
 	}
 
+	if (options.tsConfigPath) {
+		options.tsConfigPath = slash(options.tsConfigPath);
+	}
+
 	if (options.tsConfig) {
 		// If the tsconfig extends from another file, we need to ensure that the file is covered by the tsconfig
 		// or not. The basefile could have includes/excludes/files properties that should be applied to the final tsconfig representation.
@@ -213,10 +218,10 @@ const handleTSConfig = async options => {
 		// Only use our default tsconfig if no other tsconfig is found - otherwise extend the found config for linting
 		options.tsConfig = options.tsConfigPath ? {extends: options.tsConfigPath} : TSCONFIG_DEFAULTS;
 		options.tsConfigHash = new MurmurHash3(stringify(options.tsConfig)).result();
-		options.tsConfigPath = path.join(
+		options.tsConfigPath = slash(path.join(
 			cacheLocation(options.cwd),
 			`tsconfig.${options.tsConfigHash}.json`,
-		);
+		));
 	}
 
 	options.eslintConfigId = options.eslintConfigId.hash(options.tsConfigPath);
@@ -683,19 +688,19 @@ const tsConfigResolvePaths = (tsConfig, tsConfigPath) => {
 
 	if (Array.isArray(tsConfig.files)) {
 		tsConfig.files = tsConfig.files.map(
-			filePath => path.resolve(tsConfigDirectory, filePath),
+			filePath => slash(path.resolve(tsConfigDirectory, filePath)),
 		);
 	}
 
 	if (Array.isArray(tsConfig.include)) {
 		tsConfig.include = tsConfig.include.map(
-			globPath => path.resolve(tsConfigDirectory, globPath),
+			globPath => slash(path.resolve(tsConfigDirectory, globPath)),
 		);
 	}
 
 	if (Array.isArray(tsConfig.exclude)) {
 		tsConfig.exclude = tsConfig.exclude.map(
-			globPath => path.resolve(tsConfigDirectory, globPath),
+			globPath => slash(path.resolve(tsConfigDirectory, globPath)),
 		);
 	}
 

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -175,10 +175,6 @@ const handleTSConfig = async options => {
 		options.tsConfig = searchResults.config;
 	}
 
-	if (options.tsConfigPath) {
-		options.tsConfigPath = slash(options.tsConfigPath);
-	}
-
 	if (options.tsConfig) {
 		// If the tsconfig extends from another file, we need to ensure that the file is covered by the tsconfig
 		// or not. The basefile could have includes/excludes/files properties that should be applied to the final tsconfig representation.
@@ -218,10 +214,10 @@ const handleTSConfig = async options => {
 		// Only use our default tsconfig if no other tsconfig is found - otherwise extend the found config for linting
 		options.tsConfig = options.tsConfigPath ? {extends: options.tsConfigPath} : TSCONFIG_DEFAULTS;
 		options.tsConfigHash = new MurmurHash3(stringify(options.tsConfig)).result();
-		options.tsConfigPath = slash(path.join(
+		options.tsConfigPath = path.join(
 			cacheLocation(options.cwd),
 			`tsconfig.${options.tsConfigHash}.json`,
-		));
+		);
 	}
 
 	options.eslintConfigId = options.eslintConfigId.hash(options.tsConfigPath);

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -551,7 +551,7 @@ test('mergeWithFileConfig: XO engine options false supersede package.json\'s', a
 test('mergeWithFileConfig: resolves expected typescript file options', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'child');
 	const filePath = path.resolve(cwd, 'file.ts');
-	const tsConfigPath = slash(path.resolve(cwd, 'tsconfig.json'));
+	const tsConfigPath = path.resolve(cwd, 'tsconfig.json');
 	const tsConfig = await readJson(tsConfigPath);
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	const eslintConfigId = new MurmurHash3(path.resolve(cwd, 'package.json')).hash(tsConfigPath).result();
@@ -573,7 +573,7 @@ test('mergeWithFileConfig: resolves expected tsx file options', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'child');
 	const filePath = path.resolve(cwd, 'file.tsx');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
-	const tsConfigPath = slash(path.resolve(cwd, 'tsconfig.json'));
+	const tsConfigPath = path.resolve(cwd, 'tsconfig.json');
 	const tsConfig = await readJson(tsConfigPath);
 	const eslintConfigId = new MurmurHash3(path.join(cwd, 'package.json')).hash(tsConfigPath).result();
 	const expected = {
@@ -593,7 +593,7 @@ test('mergeWithFileConfig: resolves expected tsx file options', async t => {
 test('mergeWithFileConfig: uses specified parserOptions.project as tsconfig', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'parseroptions-project');
 	const filePath = path.resolve(cwd, 'included-file.ts');
-	const expectedTsConfigPath = slash(path.resolve(cwd, 'projectconfig.json'));
+	const expectedTsConfigPath = path.resolve(cwd, 'projectconfig.json');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	t.is(options.tsConfigPath, expectedTsConfigPath);
 });
@@ -603,13 +603,13 @@ test('mergeWithFileConfig: correctly resolves relative tsconfigs excluded file',
 	const excludedFilePath = path.resolve(cwd, 'excluded-file.ts');
 	const excludeTsConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath: excludedFilePath});
-	t.regex(options.tsConfigPath, excludeTsConfigPath);
+	t.regex(slash(options.tsConfigPath), excludeTsConfigPath);
 });
 
 test('mergeWithFileConfig: correctly resolves relative tsconfigs included file', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'relative-configs');
 	const includedFilePath = path.resolve(cwd, 'included-file.ts');
-	const includeTsConfigPath = slash(path.resolve(cwd, 'config/tsconfig.json'));
+	const includeTsConfigPath = path.resolve(cwd, 'config/tsconfig.json');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath: includedFilePath});
 	t.is(options.tsConfigPath, includeTsConfigPath);
 });
@@ -619,7 +619,7 @@ test('mergeWithFileConfig: uses generated tsconfig if specified parserOptions.pr
 	const filePath = path.resolve(cwd, 'excluded-file.ts');
 	const expectedTsConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
-	t.regex(options.tsConfigPath, expectedTsConfigPath);
+	t.regex(slash(options.tsConfigPath), expectedTsConfigPath);
 });
 
 test('mergeWithFileConfig: uses generated tsconfig if specified parserOptions.project misses file', async t => {
@@ -627,7 +627,7 @@ test('mergeWithFileConfig: uses generated tsconfig if specified parserOptions.pr
 	const filePath = path.resolve(cwd, 'missed-by-options-file.ts');
 	const expectedTsConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
-	t.regex(options.tsConfigPath, expectedTsConfigPath);
+	t.regex(slash(options.tsConfigPath), expectedTsConfigPath);
 });
 
 test('mergeWithFileConfig: auto generated ts config extends found ts config if file is not covered', async t => {
@@ -635,7 +635,7 @@ test('mergeWithFileConfig: auto generated ts config extends found ts config if f
 	const filePath = path.resolve(cwd, 'does-not-matter.ts');
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	const expected = {
-		extends: slash(path.resolve(cwd, 'tsconfig.json')),
+		extends: path.resolve(cwd, 'tsconfig.json'),
 	};
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
@@ -655,7 +655,7 @@ test('mergeWithFileConfig: auto generated ts config extends found ts config if f
 	const filePath = path.resolve(cwd, 'excluded-file.ts');
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	const expected = {
-		extends: slash(path.resolve(cwd, 'tsconfig.json')),
+		extends: path.resolve(cwd, 'tsconfig.json'),
 	};
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
@@ -673,7 +673,7 @@ test('mergeWithFileConfig: creates temp tsconfig if none present', async t => {
 
 test('mergeWithFileConfig: tsconfig can properly extend configs in node_modules', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'extends-module');
-	const expectedConfigPath = slash(path.join(cwd, 'tsconfig.json'));
+	const expectedConfigPath = path.join(cwd, 'tsconfig.json');
 	const filePath = path.resolve(cwd, 'does-not-matter.ts');
 	await t.notThrowsAsync(manager.mergeWithFileConfig({cwd, filePath}));
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
@@ -682,7 +682,7 @@ test('mergeWithFileConfig: tsconfig can properly extend configs in node_modules'
 
 test('mergeWithFileConfig: tsconfig can properly extend tsconfig base node_modules', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'extends-tsconfig-bases');
-	const expectedConfigPath = slash(path.join(cwd, 'tsconfig.json'));
+	const expectedConfigPath = path.join(cwd, 'tsconfig.json');
 	const filePath = path.resolve(cwd, 'does-not-matter.ts');
 	await t.notThrowsAsync(manager.mergeWithFileConfig({cwd, filePath}));
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -551,7 +551,7 @@ test('mergeWithFileConfig: XO engine options false supersede package.json\'s', a
 test('mergeWithFileConfig: resolves expected typescript file options', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'child');
 	const filePath = path.resolve(cwd, 'file.ts');
-	const tsConfigPath = path.resolve(cwd, 'tsconfig.json');
+	const tsConfigPath = slash(path.resolve(cwd, 'tsconfig.json'));
 	const tsConfig = await readJson(tsConfigPath);
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	const eslintConfigId = new MurmurHash3(path.resolve(cwd, 'package.json')).hash(tsConfigPath).result();
@@ -573,7 +573,7 @@ test('mergeWithFileConfig: resolves expected tsx file options', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'child');
 	const filePath = path.resolve(cwd, 'file.tsx');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
-	const tsConfigPath = path.resolve(cwd, 'tsconfig.json');
+	const tsConfigPath = slash(path.resolve(cwd, 'tsconfig.json'));
 	const tsConfig = await readJson(tsConfigPath);
 	const eslintConfigId = new MurmurHash3(path.join(cwd, 'package.json')).hash(tsConfigPath).result();
 	const expected = {
@@ -593,7 +593,7 @@ test('mergeWithFileConfig: resolves expected tsx file options', async t => {
 test('mergeWithFileConfig: uses specified parserOptions.project as tsconfig', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'parseroptions-project');
 	const filePath = path.resolve(cwd, 'included-file.ts');
-	const expectedTsConfigPath = path.resolve(cwd, 'projectconfig.json');
+	const expectedTsConfigPath = slash(path.resolve(cwd, 'projectconfig.json'));
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	t.is(options.tsConfigPath, expectedTsConfigPath);
 });
@@ -609,7 +609,7 @@ test('mergeWithFileConfig: correctly resolves relative tsconfigs excluded file',
 test('mergeWithFileConfig: correctly resolves relative tsconfigs included file', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'relative-configs');
 	const includedFilePath = path.resolve(cwd, 'included-file.ts');
-	const includeTsConfigPath = path.resolve(cwd, 'config/tsconfig.json');
+	const includeTsConfigPath = slash(path.resolve(cwd, 'config/tsconfig.json'));
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath: includedFilePath});
 	t.is(options.tsConfigPath, includeTsConfigPath);
 });
@@ -635,7 +635,7 @@ test('mergeWithFileConfig: auto generated ts config extends found ts config if f
 	const filePath = path.resolve(cwd, 'does-not-matter.ts');
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	const expected = {
-		extends: path.resolve(cwd, 'tsconfig.json'),
+		extends: slash(path.resolve(cwd, 'tsconfig.json')),
 	};
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
@@ -645,7 +645,7 @@ test('mergeWithFileConfig: auto generated ts config extends found ts config if f
 test('mergeWithFileConfig: used found ts config if file is covered', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'extends-config');
 	const filePath = path.resolve(cwd, 'foo.ts');
-	const expectedConfigPath = path.resolve(cwd, 'tsconfig.json');
+	const expectedConfigPath = slash(path.resolve(cwd, 'tsconfig.json'));
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	t.is(slash(options.tsConfigPath), expectedConfigPath);
 });
@@ -655,7 +655,7 @@ test('mergeWithFileConfig: auto generated ts config extends found ts config if f
 	const filePath = path.resolve(cwd, 'excluded-file.ts');
 	const expectedConfigPath = new RegExp(`${slash(cwd)}/node_modules/.cache/xo-linter/tsconfig\\..*\\.json[\\/]?$`, 'u');
 	const expected = {
-		extends: path.resolve(cwd, 'tsconfig.json'),
+		extends: slash(path.resolve(cwd, 'tsconfig.json')),
 	};
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
 	t.regex(slash(options.tsConfigPath), expectedConfigPath);
@@ -673,7 +673,7 @@ test('mergeWithFileConfig: creates temp tsconfig if none present', async t => {
 
 test('mergeWithFileConfig: tsconfig can properly extend configs in node_modules', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'extends-module');
-	const expectedConfigPath = path.join(cwd, 'tsconfig.json');
+	const expectedConfigPath = slash(path.join(cwd, 'tsconfig.json'));
 	const filePath = path.resolve(cwd, 'does-not-matter.ts');
 	await t.notThrowsAsync(manager.mergeWithFileConfig({cwd, filePath}));
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
@@ -682,7 +682,7 @@ test('mergeWithFileConfig: tsconfig can properly extend configs in node_modules'
 
 test('mergeWithFileConfig: tsconfig can properly extend tsconfig base node_modules', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'extends-tsconfig-bases');
-	const expectedConfigPath = path.join(cwd, 'tsconfig.json');
+	const expectedConfigPath = slash(path.join(cwd, 'tsconfig.json'));
 	const filePath = path.resolve(cwd, 'does-not-matter.ts');
 	await t.notThrowsAsync(manager.mergeWithFileConfig({cwd, filePath}));
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -645,9 +645,9 @@ test('mergeWithFileConfig: auto generated ts config extends found ts config if f
 test('mergeWithFileConfig: used found ts config if file is covered', async t => {
 	const cwd = path.resolve('fixtures', 'typescript', 'extends-config');
 	const filePath = path.resolve(cwd, 'foo.ts');
-	const expectedConfigPath = slash(path.resolve(cwd, 'tsconfig.json'));
+	const expectedConfigPath = path.resolve(cwd, 'tsconfig.json');
 	const {options} = await manager.mergeWithFileConfig({cwd, filePath});
-	t.is(slash(options.tsConfigPath), expectedConfigPath);
+	t.is(options.tsConfigPath, expectedConfigPath);
 });
 
 test('mergeWithFileConfig: auto generated ts config extends found ts config if file is explicitly excluded', async t => {


### PR DESCRIPTION
@sindresorhus Under windows some tests on file names did not match because they were compared with different directory separators. This PR fixes this issue using the `slash` lib where it was required for my case, it is possible that for other configurations (under windows) it should be done elsewhere as well.

Fixes https://github.com/sindresorhus/type-fest/issues/451