### PR TITLE
Improve `lintFiles`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import {ESLint} from 'eslint';
-import {globby, isGitIgnored} from 'globby';
+import {globby, isGitIgnoredSync} from 'globby';
 import {isEqual} from 'lodash-es';
 import micromatch from 'micromatch';
 import arrify from 'arrify';
@@ -53,7 +53,8 @@ const lintText = async (string, options) => {
 		filePath
 		&& (
 			micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
-			|| await isGitIgnored({cwd})(filePath)
+			// TODO: Use async version when `globby` fix `isGitIgnored`
+			|| isGitIgnoredSync({cwd})(filePath)
 		)
 	) {
 		return getIgnoredReport(filePath);

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const lintText = async (string, options) => {
 		filePath
 		&& (
 			micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
-			|| (await isGitIgnored({cwd})(filePath))
+			|| await isGitIgnored({cwd})(filePath)
 		)
 	) {
 		return getIgnoredReport(filePath);
@@ -90,7 +90,7 @@ const lintFiles = async (patterns, options) => {
 					if (
 						micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
 						// eslint-disable-next-line no-await-in-loop
-						|| (await eslint.isPathIgnored(filePath))
+						|| await eslint.isPathIgnored(filePath)
 					) {
 						continue;
 					}

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const lintText = async (string, options) => {
 		filePath
 		&& (
 			micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
-			|| isGitIgnoredSync({cwd, ignore: ignorePatterns})(filePath)
+			|| isGitIgnoredSync({cwd})(filePath)
 		)
 	) {
 		return getIgnoredReport(filePath);
@@ -87,16 +87,11 @@ const lintFiles = async (patterns, options) => {
 				for (const options of filesWithOptions) {
 					const {filePath, eslintOptions} = options;
 					const {cwd, baseConfig: {ignorePatterns}} = eslintOptions;
-					if (filePath
-						&& (
-							micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
-							|| isGitIgnoredSync({cwd, ignore: ignorePatterns})(filePath)
-						)) {
-						continue;
-					}
-
-					// eslint-disable-next-line no-await-in-loop
-					if ((await eslint.isPathIgnored(filePath))) {
+					if (
+						micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
+						// eslint-disable-next-line no-await-in-loop
+						|| (await eslint.isPathIgnored(filePath))
+					) {
 						continue;
 					}
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import {ESLint} from 'eslint';
-import {globby, isGitIgnoredSync} from 'globby';
+import {globby, isGitIgnored} from 'globby';
 import {isEqual} from 'lodash-es';
 import micromatch from 'micromatch';
 import arrify from 'arrify';
@@ -53,7 +53,7 @@ const lintText = async (string, options) => {
 		filePath
 		&& (
 			micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
-			|| isGitIgnoredSync({cwd})(filePath)
+			|| (await isGitIgnored({cwd})(filePath))
 		)
 	) {
 		return getIgnoredReport(filePath);

--- a/index.js
+++ b/index.js
@@ -53,7 +53,6 @@ const lintText = async (string, options) => {
 		filePath
 		&& (
 			micromatch.isMatch(path.relative(cwd, filePath), ignorePatterns)
-			// TODO: Use async version when `globby` fix `isGitIgnored`
 			|| isGitIgnoredSync({cwd})(filePath)
 		)
 	) {


### PR DESCRIPTION
 Remove unnecessary `isGitIgnoredSync` call.

Files ignored by `.gitignore` already checked when globbing files https://github.com/xojs/xo/blob/b15cbfed6e7db7100158fc9d614b69621449604e/index.js#L31