### PR TITLE
Fix conflict of `@typescript-eslint/member-delimiter-style` with `semicolon` option

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -380,6 +380,20 @@ const buildXOConfig = options => config => {
 	if (options.semicolon === false && !options.prettier) {
 		if (options.ts) {
 			config.baseConfig.rules['@typescript-eslint/semi'] = ['error', 'never'];
+			// Set the delimiter of multiline to none because of https://github.com/xojs/xo/issues/675
+			config.baseConfig.rules['@typescript-eslint/member-delimiter-style'] = [
+				'error',
+				{
+					multiline: {
+						delimiter: 'none',
+						requireLast: false,
+					},
+					singleline: {
+						delimiter: 'semi',
+						requireLast: false,
+					},
+				},
+			];
 		} else {
 			config.baseConfig.rules.semi = ['error', 'never'];
 		}


### PR DESCRIPTION
Fixes #675

This PR is my attempt to fix the problem by manually overriding and merging the `multiline` options with the default options in [eslint-config-xo-typescript](https://github.com/xojs/eslint-config-xo-typescript/blob/main/index.js#L283-L295)
