### PR TITLE
Upgrade bundled typescript-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
 	],
 	"dependencies": {
 		"@eslint/eslintrc": "^1.3.3",
-		"@typescript-eslint/eslint-plugin": "^5.57.1",
-		"@typescript-eslint/parser": "^5.57.1",
+		"@typescript-eslint/eslint-plugin": "^5.59.1",
+		"@typescript-eslint/parser": "^5.59.1",
 		"arrify": "^3.0.0",
 		"cosmiconfig": "^8.1.3",
 		"define-lazy-prop": "^3.0.0",


### PR DESCRIPTION
Among other improvements, this fixes a crash in the `@typescript-eslint/unified-signatures` rule: typescript-eslint/typescript-eslint#6940.

(Alternatively, since Node.js 14 reaches [end-of-life](https://github.com/nodejs/Release#release-schedule) this weekend, maybe we can revert #624 so that users can get the latest typescript-eslint independently again?)