### PR TITLE
Bump eslint-plugin-unicorn from 46.0.0 to 47.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"eslint-plugin-n": "^15.7.0",
 		"eslint-plugin-no-use-extend-native": "^0.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
-		"eslint-plugin-unicorn": "^46.0.0",
+		"eslint-plugin-unicorn": "^47.0.0",
 		"esm-utils": "^4.1.2",
 		"find-cache-dir": "^4.0.0",
 		"find-up": "^6.3.0",

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -99,7 +99,7 @@ test('buildConfig: prettier: true', t => {
 		trailingComma: 'all',
 	}]);
 	// eslint-prettier-config must always be last
-	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'plugin:prettier/recommended');
+	t.is(config.baseConfig.extends.at(-1), 'plugin:prettier/recommended');
 	// Indent rule is not enabled
 	t.is(config.baseConfig.rules.indent, undefined);
 	// Semi rule is not enabled
@@ -125,8 +125,8 @@ test('buildConfig: prettier: true, typescript file', t => {
 	}]);
 
 	// eslint-prettier-config must always be last
-	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'plugin:prettier/recommended');
-	t.regex(config.baseConfig.extends[config.baseConfig.extends.length - 2], /xo-typescript/);
+	t.is(config.baseConfig.extends.at(-1), 'plugin:prettier/recommended');
+	t.regex(config.baseConfig.extends.at(-2), /xo-typescript/);
 
 	// Indent rule is not enabled
 	t.is(config.baseConfig.rules.indent, undefined);
@@ -430,7 +430,7 @@ test('buildConfig: extends', t => {
 test('buildConfig: typescript', t => {
 	const config = manager.buildConfig({ts: true, tsConfigPath: './tsconfig.json'});
 
-	t.regex(config.baseConfig.extends[config.baseConfig.extends.length - 1], /xo-typescript/);
+	t.regex(config.baseConfig.extends.at(-1), /xo-typescript/);
 	t.is(config.baseConfig.parser, require.resolve('@typescript-eslint/parser'));
 	t.deepEqual(config.baseConfig.parserOptions, {
 		warnOnUnsupportedTypeScriptVersion: false,


### PR DESCRIPTION
Upgrades `eslint-plugin-unicorn` from `46.0.0` to `47.0.0`.
- https://www.npmjs.com/package/eslint-plugin-unicorn/v/47.0.0
- https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v47.0.0 

It appears there's an issue with current `xo` + `eslint` at `8.40.0` + outdated `eslint-plugin-unicorn`.
- https://github.com/xojs/xo/issues/718

Apparently upgrading `eslint-plugin-unicorn` resolves the issue for people.

- https://github.com/eslint/eslint/issues/17167#issuecomment-1539088097

Note, this change Likely requires dropping support for EOL Node 14.
- https://github.com/xojs/xo/pull/721

May resolve https://github.com/xojs/xo/issues/718 once a new version of `xo` is released.