### PR TITLE
Require Node 16 and drop support for Node 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 18
           - 16
-          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"bin": "./cli.js",
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=16.20"
 	},
 	"scripts": {
 		"test:clean": "find ./test -type d -name 'node_modules' -prune -not -path ./test/fixtures/project/node_modules -exec rm -rf '{}' +",


### PR DESCRIPTION
We should make Node 16 required and drop support for Node 14 as it's already [end-of-life as of April 30th this year](https://github.com/nodejs/Release/tree/6a881a11363eb601f17b2d46e3f1664db5ce2a3b#end-of-life-releases).

![Screenshot from 2023-06-07 17-23-04](https://github.com/xojs/xo/assets/1557529/5f23f312-f424-425c-bf09-41f4245c7468)

Note, not sure what kind of bumps we want to do in `package.json` if any re: we did so when we [bumped 12 to 14](https://github.com/xojs/xo/commit/91d10d1beb29cc6bd2db767635d7696931f9e871).

Inspired by https://github.com/xojs/xo/pull/720#issuecomment-1580188300