### PR TITLE
Add Node 20 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 20
           - 18
           - 16
           - 14


### PR DESCRIPTION
We should probably add Node 20 to CI. It's been out for some time now, should be stable enough for CI.

Related to
- https://github.com/xojs/xo/pull/721

Inspired by https://github.com/xojs/xo/pull/720#issuecomment-1580188300