### PR TITLE
Bump eslint-plugin-unicorn from 46.0.0 to 46.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"eslint-plugin-n": "^15.7.0",
 		"eslint-plugin-no-use-extend-native": "^0.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
-		"eslint-plugin-unicorn": "^46.0.0",
+		"eslint-plugin-unicorn": "^46.0.1",
 		"esm-utils": "^4.1.2",
 		"find-cache-dir": "^4.0.0",
 		"find-up": "^6.3.0",


### PR DESCRIPTION
Upgrades `eslint-plugin-unicorn` from `46.0.0` to `47.0.1`.
- https://www.npmjs.com/package/eslint-plugin-unicorn/v/46.0.1
- https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v46.0.1

It appears there's an issue with current `xo` + `eslint` at `8.40.0` + outdated `eslint-plugin-unicorn`.
- https://github.com/xojs/xo/issues/718

Apparently upgrading `eslint-plugin-unicorn` resolves the issue for people.

- https://github.com/eslint/eslint/issues/17167#issuecomment-1539088097

May resolve https://github.com/xojs/xo/issues/718 once a new version of `xo` is released.