### PR TITLE
Polish XO badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 > JavaScript/TypeScript linter (ESLint wrapper) with great defaults
 
 [![Coverage Status](https://codecov.io/gh/xojs/xo/branch/main/graph/badge.svg)](https://codecov.io/gh/xojs/xo/branch/main)
-[![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray)](https://github.com/xojs/xo)
+[![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto&logoWidth=20)](https://github.com/xojs/xo)
 
 Opinionated but configurable ESLint wrapper with lots of goodies included. Enforces strict and readable code. Never discuss code style on a pull request again! No decision-making. No `.eslintrc` to manage. It just works!
 
@@ -481,10 +481,10 @@ XO is based on ESLint. This project started out as just a shareable ESLint confi
 
 ## Badge
 
-Show the world you're using XO → [![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray)](https://github.com/xojs/xo)
+Show the world you're using XO → [![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto&logoWidth=20)](https://github.com/xojs/xo)
 
 ```md
-[![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray)](https://github.com/xojs/xo)
+[![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto&logoWidth=20)](https://github.com/xojs/xo)
 ```
 
 Or [customize the badge](https://github.com/xojs/xo/issues/689#issuecomment-1253127616).


### PR DESCRIPTION
The new parameter `logoSize=auto` was added in https://github.com/badges/shields/pull/9191

We can have a better visual now.

```
https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray
https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto
https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto&logoWidth=20
```

![](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray)
![](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto)
![](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto&logoWidth=20)

Which one would you prefer?

I will update https://github.com/xojs/xo/issues/689#issuecomment-1253127616 after you choose.