### PR TITLE
Respect `nodeVersion: false` option

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -116,8 +116,8 @@ const mergeWithFileConfig = async options => {
 	const {config: enginesOptions} = (await packageConfigExplorer.search(searchPath)) || {};
 
 	options = normalizeOptions({
-		...xoOptions,
 		...(enginesOptions && enginesOptions.node && semver.validRange(enginesOptions.node) ? {nodeVersion: enginesOptions.node} : {}),
+		...xoOptions,
 		...options,
 	});
 	options.extensions = [...DEFAULT_EXTENSION, ...(options.extensions || [])];


### PR DESCRIPTION
- Fixes https://github.com/xojs/xo/issues/598
- Follows https://github.com/xojs/xo/pull/761
- Tested in https://github.com/refined-github/refined-github/pull/7588

This is confirmed to fix the issue. Also I was able to verify that setting `nodeVersion: "20"` in an override restores the node-related rules.