### PR TITLE
fix: restore typescript extension support

### DIFF
--- a/config/plugins.cjs
+++ b/config/plugins.cjs
@@ -315,13 +315,6 @@ module.exports = {
 		'n/file-extension-in-import': [
 			'error',
 			'always',
-			{
-				// TypeScript doesn't yet support using extensions and fails with error TS2691.
-				'.ts': 'never',
-				'.tsx': 'never',
-				'.mts': 'never',
-				'.cts': 'never',
-			},
 		],
 		'n/no-mixed-requires': [
 			'error',


### PR DESCRIPTION
fixes #763 

As far as I understand the updated rule checks for the listed extensions and only allows the listed ones now. `js` wasn't included and therefore assumed as forbidden.

As the rule was improved the reason for these custom options in gone now. It automatically assumes `js` for `ts` now.

https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/file-extension-in-import.md mentions `typescriptExtensionMap` but the default one seems to be fine so no need to configure it.