### PR TITLE
Fix missing declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 	},
 	"files": [
 		"dist/lib",
-		"dist/*.js"
+		"dist/*.js",
+		"dist/*.d.ts"
 	],
 	"keywords": [
 		"cli-app",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"outDir": "dist",
 		"resolveJsonModule": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"declaration": true
 	},
 	"include": [
 		"**/*.ts",


### PR DESCRIPTION
See https://www.jsdelivr.com/package/npm/xo?tab=files&version=0.61.0-0&path=dist

The `index.d.ts` is missing. It looks we misconfigured the `files` field in `package.json`.

I've added `dist/*.d.ts` to `files` to fix this issue.

In the meantime, we have those `dist/lib/*.js.map` files published to npm. Is that expected? If yes, do we need to add `dist/*.js.map` to `files` as well?