### PR TITLE
Ignore source map files while publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 		"test:setup": "node scripts/setup-tests"
 	},
 	"files": [
-		"dist/lib",
+		"dist/lib/*.js",
+		"dist/lib/*.d.ts",
 		"dist/*.js",
 		"dist/*.d.ts"
 	],


### PR DESCRIPTION
Please correct me if I'm wrong.

It looks like we only used those source map files for testing purposes. Maybe we could ignore them while publishing to npm.