### PR TITLE
Use get-tsconfig for ts matching

### DIFF
--- a/lib/handle-ts-files.ts
+++ b/lib/handle-ts-files.ts
@@ -15,7 +15,7 @@ If no tsconfig is found, it will create a fallback tsconfig file in the `node_mo
 @returns The unmatched files.
 */
 export async function handleTsconfig({cwd, files}: {cwd: string; files: string[]}) {
-	const {config: tsConfig = tsconfigDefaults, path: tsConfigPath} = getTsconfig(cwd) ?? {};
+	const {config: tsConfig = tsconfigDefaults, path: tsConfigPath} = (files.length === 1 ? getTsconfig(path.dirname(files[0] ?? '')) : getTsconfig(cwd)) ?? {};
 
 	tsConfig.compilerOptions ??= {};
 
@@ -52,7 +52,7 @@ export async function handleTsconfig({cwd, files}: {cwd: string; files: string[]
 			const exclude = Array.isArray(tsConfig.exclude) ? tsConfig.exclude : [];
 			// If we also have an exlcude we need to check all the arrays, (files, include, exclude)
 			// this check not excluded and included in one of the file/include array
-			hasMatch = !micromatch.contains(filePath, exclude, micromatchOptions) && micromatch.isMatch(filePath, [...include, ...files], micromatchOptions);
+			hasMatch = !micromatch.contains(filePath, exclude, micromatchOptions) && micromatch.contains(filePath, [...include, ...files], micromatchOptions);
 		}
 
 		if (!hasMatch) {


### PR DESCRIPTION
Noticed that our logic was having some issues with nested tsconfigs

So this PR:

uses `getTsconfig` for every file, due to lots of internal caching this appears to be very fast still and behaves much more like ts lang server does by finding the nearest tsconfig.json rather than just looking in the root. 

uses get-tsconfigs file matcher which is much more accurate than our custom logic based on micromatch. 

We no longer attempt to re-use any of the users tsconfigs if they are matched, we only write our own default tsconfig for unmatched files. This should provide a more consistent xo experience.

Added a few tests for nested configs and edge cases.



