### PR TITLE
Fix: Behaviour of `print-config` option with relative file path

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -232,7 +232,9 @@ if (typeof cliOptions.printConfig === 'string') {
 		process.exit(1);
 	}
 
-	const config = await new Xo(linterOptions, baseXoConfigOptions).calculateConfigForFile(cliOptions.printConfig);
+	const absoluteFilePath = path.resolve(cliOptions.cwd, cliOptions.printConfig);
+
+	const config = await new Xo(linterOptions, baseXoConfigOptions).calculateConfigForFile(absoluteFilePath);
 	console.log(JSON.stringify(config, undefined, '\t'));
 } else {
 	const xo = new Xo(linterOptions, baseXoConfigOptions);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -113,6 +113,22 @@ test('xo --print-config ts', async t => {
 	t.true('rules' in config);
 });
 
+test('xo --print-config relative path', async t => {
+	const fileName = 'test.ts';
+	const filePath = path.join(t.context.cwd, fileName);
+	await fs.writeFile(filePath, dedent`console.log('hello');\n`, 'utf8');
+	const {stdout} = await $`node ./dist/cli --cwd ${t.context.cwd} --print-config=${fileName}`;
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const config = JSON.parse(stdout);
+	t.true(typeof config === 'object');
+	t.true('rules' in config);
+});
+
+test('xo --print-config no path', async t => {
+	const {stderr}: ExecaError = await t.throwsAsync($`node ./dist/cli --cwd ${t.context.cwd} --print-config`);
+	t.is('The `--print-config` flag must be used with exactly one filename', stderr?.toString() ?? '');
+});
+
 test('xo --ignore', async t => {
 	const testFile = path.join(t.context.cwd, 'test.js');
 	const ignoredFile = path.join(t.context.cwd, 'ignored.js');


### PR DESCRIPTION
Fixes #815.

Resolves the file path passed to `print-config` before calling `calculateConfigForFile`.

Also, adds a test for when no path is provided.