### PR TITLE
improved ts rules handling

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -48,8 +48,6 @@ export const config: Linter.Config[] = [
 			'@eslint-community/eslint-comments': pluginComments,
 			promise: pluginPromise,
 			'@stylistic': stylisticPlugin, // eslint-disable-line @typescript-eslint/naming-convention
-			// Load the typescript plugin for all files, so that it can be used in the config
-			...configXoTypescript[1]?.plugins,
 		},
 		languageOptions: {
 			globals: {
@@ -379,6 +377,7 @@ export const config: Linter.Config[] = [
 	},
 	{
 		name: 'Xo TypeScript',
+		plugins: configXoTypescript[1]?.plugins,
 		files: [tsFilesGlob],
 		languageOptions: {
 			...configXoTypescript[1]?.languageOptions,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -48,6 +48,8 @@ export const config: Linter.Config[] = [
 			'@eslint-community/eslint-comments': pluginComments,
 			promise: pluginPromise,
 			'@stylistic': stylisticPlugin, // eslint-disable-line @typescript-eslint/naming-convention
+			// Load the typescript plugin for all files, so that it can be used in the config
+			...configXoTypescript[1]?.plugins,
 		},
 		languageOptions: {
 			globals: {
@@ -377,7 +379,6 @@ export const config: Linter.Config[] = [
 	},
 	{
 		name: 'Xo TypeScript',
-		plugins: configXoTypescript[1]?.plugins,
 		files: [tsFilesGlob],
 		languageOptions: {
 			...configXoTypescript[1]?.languageOptions,

--- a/lib/handle-ts-files.ts
+++ b/lib/handle-ts-files.ts
@@ -33,10 +33,6 @@ export async function handleTsconfig({cwd, files}: {cwd: string; files: string[]
 
 	const fallbackTsConfigPath = path.join(cwd, 'node_modules', '.cache', cacheDirName, 'tsconfig.xo.json');
 
-	delete tsConfig.include;
-	delete tsConfig.exclude;
-	delete tsConfig.files;
-
 	tsConfig.files = unincludedFiles;
 
 	if (unincludedFiles.length > 0) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,15 @@
-import arrify from 'arrify';
-import {type SetRequired} from 'type-fest';
+import path from 'node:path';
+import micromatch from 'micromatch';
 import {type Linter} from 'eslint';
-import {allFilesGlob} from './constants.js';
+import {type SetRequired} from 'type-fest';
+import arrify from 'arrify';
+import configXoTypescript from 'eslint-config-xo-typescript';
 import {type XoConfigItem} from './types.js';
+import {
+	allFilesGlob,
+	jsExtensions,
+	jsFilesGlob,
+} from './constants.js';
 
 /**
 Convert a `xo` config item to an ESLint config item.
@@ -35,4 +42,110 @@ export const xoToEslintConfigItem = (xoConfig: XoConfigItem): SetRequired<Linter
 	eslintConfig.ignores &&= arrify(xoConfig.ignores);
 
 	return eslintConfig;
+};
+
+/**
+Function used to match files which should be included in the `tsconfig.json` files.
+@param cwd - The current working directory to resolve relative filepaths.
+@param files - The _absolute_ file paths to match against the globs.
+@param globs - The globs to match the files against.
+@param ignores - The globs to ignore when matching the files.
+@returns An array of file paths that match the globs and do not match the ignores.
+*/
+export const matchFilesForTsConfig = (cwd: string, files: string[], globs: string[], ignores: string[]) => micromatch(
+	files.map(file => path.normalize(path.relative(cwd, file))),
+	// https://github.com/micromatch/micromatch/issues/217
+	globs.map(glob => path.normalize(glob)),
+	{
+		dot: true,
+		ignore: ignores.map(file => path.normalize(file)),
+		cwd,
+	},
+).map(file => path.resolve(cwd, file));
+
+/**
+Once a config is resolved, it is pre-processed to ensure that all properties are set correctly.
+This includes ensuring that user-defined properties can override xo defaults, and that files are parsed correctly
+and performantly based on the users xo config.
+@param xoConfig - The flat xo config to pre-process.
+@returns The pre-processed flat xo config.
+*/
+export const preProcessXoConfig = (xoConfig: XoConfigItem[]): // eslint-disable-line complexity
+{config: XoConfigItem[]; tsFilesGlob: string[]; tsFilesIgnoresGlob: string[]} => {
+	const tsFilesGlob: string[] = [];
+	const tsFilesIgnoresGlob: string[] = [];
+	for (const [idx, config] of xoConfig.entries()) {
+		// We can skip the first config  item, as it is the base config item.
+		if (idx === 0) {
+			continue;
+		}
+
+		// Use ts parser/plugin for js files if the config contains TypeScript rules which are applied to JS files.
+		// typescript-eslint rules set to "off" are ignored and not applied to JS files.
+		if (
+			config.rules
+			&& !config.languageOptions?.parser
+			&& !config.languageOptions?.parserOptions?.['project']
+			&& !config.plugins?.['@typescript-eslint']
+		) {
+			const hasTsRules = Object.entries(config.rules).some(rulePair => {
+				// If its not a @typescript-eslint rule, we don't care
+				if (!rulePair[0].startsWith('@typescript-eslint/')) {
+					return false;
+				}
+
+				if (Array.isArray(rulePair[1])) {
+					return rulePair[1]?.[0] !== 'off' && rulePair[1]?.[0] !== 0;
+				}
+
+				return rulePair[1] !== 'off'
+					&& rulePair[1] !== 0;
+			});
+
+			if (hasTsRules) {
+				let isAppliedToJsFiles = false;
+
+				if (config.files) {
+					const normalizedFiles = arrify(config.files).map(file => path.normalize(file));
+					// Strip the basename off any globs
+					const globs = normalizedFiles.map(file => micromatch.scan(file, {dot: true}).glob).filter(Boolean);
+					// Check if the files globs match a test file with a js extension
+					// If not, check that the file paths match a js extension
+					isAppliedToJsFiles = micromatch.some(jsExtensions.map(ext => `test.${ext}`), globs, {dot: true})
+						|| micromatch.some(normalizedFiles, jsFilesGlob, {dot: true});
+				} else if (config.files === undefined) {
+					isAppliedToJsFiles = true;
+				}
+
+				if (isAppliedToJsFiles) {
+					config.languageOptions ??= {};
+					config.plugins ??= {};
+					config.plugins = {
+						...config.plugins,
+						...configXoTypescript[1]?.plugins,
+					};
+					config.languageOptions.parser = configXoTypescript[1]?.languageOptions?.parser;
+					tsFilesGlob.push(...arrify(config.files ?? allFilesGlob));
+					tsFilesIgnoresGlob.push(...arrify(config.ignores));
+				}
+			}
+		}
+
+		// If a user sets the parserOptions.project or projectService or tsconfigRootDir, we need to ensure that the tsFilesGlob is set to exclude those files,
+		// as this indicates the user has opted out of the default TypeScript handling for those files.
+		if (
+			config.languageOptions?.parserOptions?.['project'] !== undefined
+			|| config.languageOptions?.parserOptions?.['projectService'] !== undefined
+			|| config.languageOptions?.parserOptions?.['tsconfigRootDir'] !== undefined
+		) {
+			// The glob itself should NOT be negated
+			tsFilesIgnoresGlob.push(...arrify(config.files ?? allFilesGlob));
+		}
+	}
+
+	return {
+		config: xoConfig,
+		tsFilesGlob,
+		tsFilesIgnoresGlob,
+	};
 };

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Simply run `$ npm init xo` (with any options) to add XO to create an `xo.config.
 
 ## Config
 
-You can configure XO options by creating an `xo.config.js` or an `xo.config.ts` file in the root directory of your project. XO supports all js/ts file extensions (js,cjs,mjs,ts,cts,mts) automatically. A XO config is an extension of ESLint's Flat Config. Like ESLint, an XO config exports an array of XO config objects. XO config objects extend [ESLint Configuration Objects](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-objects). This means all the available configuration params for ESLint also work for `XO`. However, `XO` enhances and adds extra params to the configuration objects to make them easier to work with.
+You can configure XO options by creating an `xo.config.js` or an `xo.config.ts` file in the root directory of your project, or you can add an `xo` field to your `package.json`. XO supports all js/ts file extensions (js,cjs,mjs,ts,cts,mts) automatically. A XO config is an extension of ESLint's Flat Config. Like ESLint, an XO config exports an array of XO config objects. XO config objects extend [ESLint Configuration Objects](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-objects). This means all the available configuration params for ESLint also work for `XO`. However, `XO` enhances and adds extra params to the configuration objects to make them easier to work with.
 
 ### Config types
 
@@ -124,10 +124,14 @@ const xoConfig = [...]
 
 `xo.config.ts`
 
-```js
+```ts
 import {type FlatXoConfig} from 'xo';
 
 const xoConfig: FlatXoConfig = [...]
+```
+
+```ts
+export default [...] satisfies import('xo').FlatXoConfig
 ```
 
 ### files
@@ -137,11 +141,15 @@ Default: `**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}`
 
 A glob or array of glob strings which the config object will apply. By default `XO` will apply the configuration to [all files](lib/constants.ts).
 
+> Tip: If you are adding additional @typescript-eslint rules to your config, these rules will apply to js files as well unless you separate them appropriately with the `files` option. @typescript-eslint rules set to "off" or 0, however, will have no effect on js linting.
+
 ### ignores
 
 Type: `string[]`
 
-Some [paths](lib/constants.ts) are ignored by default, including paths in `.gitignore`. Additional ignores can be added here. For global ignores, keep `ignores` as the only key in the config item.
+Some [paths](lib/constants.ts) are ignored by default, including paths in `.gitignore`. Additional ignores can be added here.
+
+> Tip: For *global* ignores, keep `ignores` as the only key in the config item. You can optionally set a `name` property. Adding more properties will cause ignores to be scoped down to your files selection, which may have unexpected effects.
 
 ### space
 
@@ -202,13 +210,15 @@ XO will automatically lint TypeScript files (`.ts`, `.mts`, `.cts`, and `.tsx`) 
 
 XO will handle the [@typescript-eslint/parser `project` option](https://typescript-eslint.io/packages/parser/#project) automatically even if you don't have a `tsconfig.json` in your project.
 
+You can opt out of XO's automatic tsconfig handling by specifying your own `languageOptions.parserOptions.project`, `languageOptions.parserOptions.projectService`, or `languageOptions.parserOptions.tsconfigRootDir`. Files in a config with these properties will be excluded from automatic tsconfig handling.
+
 ## Usage as an ESLint Configuration
 
 With the introduction of the ESLint flat config, many of the original goals of `xo` were brought into the ESLint core, and shareable configs with plugins became possible. Although we highly recommend the use of the `xo` cli, we understand that some teams need to rely on ESLint directly.
 
 For these purposes, you can still get most of the features of `xo` by using our ESLint configuration helpers.
 
-### `xoToEslintConfig`
+### xoToEslintConfig
 
 The `xoToEslintConfig` function is designed for use in an `eslint.config.js` file. It is NOT for use in an `xo.config.js` file. This function takes a `FlatXoConfig` and outputs an ESLint config object. This function will neither be able to automatically handle TS integration for you nor automatic Prettier integration. You are responsible for configuring your other tools appropriately. The `xo` cli, will however, handle all of these details for you.
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -314,30 +314,6 @@ test('ts rules properly split to avoid errors with cjs files when no options.fil
 	await t.notThrowsAsync($`node ./dist/cli --cwd ${t.context.cwd}`);
 });
 
-test('ts rules does error in cjs files if options.files is set', async t => {
-	// Write the test.cjs file
-	const filePath = path.join(t.context.cwd, 'test.cjs');
-	await fs.writeFile(filePath, dedent`console.log('hello');\n`, 'utf8');
-
-	// Write and xo config file with ts rules
-	const xoConfigPath = path.join(t.context.cwd, 'xo.config.js');
-	const xoConfig = dedent`
-		export default [
-			{ ignores: "xo.config.js" },
-			{
-				files: ["test.cjs"],
-				rules: {
-					'@typescript-eslint/no-unused-vars': 'error',
-				}
-			}
-		]
-	`;
-
-	await fs.writeFile(xoConfigPath, xoConfig, 'utf8');
-	const error = await t.throwsAsync<ExecaError>($`node ./dist/cli --cwd ${t.context.cwd}`);
-	t.true((error.stderr as string)?.includes('Could not find plugin "@typescript-eslint"'));
-});
-
 test('gives helpful error message when config creates a circular dependency', async t => {
 	const filePath = path.join(t.context.cwd, 'test.js');
 	await fs.writeFile(filePath, dedent`console.log('hello');\n`, 'utf8');
@@ -623,8 +599,6 @@ test('handles TypeScript path aliases correctly', async t => {
 
 	// This should throw an error because the import doesn't resolve
 	const error = await t.throwsAsync<ExecaError>($`node ./dist/cli --cwd ${cwd}`);
-
-	t.log(error);
 
 	// Verify that the error is related to an unresolved import
 	t.true(

--- a/test/xo/files-matching.test.ts
+++ b/test/xo/files-matching.test.ts
@@ -1,0 +1,508 @@
+
+import _test, {type TestFn} from 'ava'; // eslint-disable-line ava/use-test
+import {preProcessXoConfig, matchFilesForTsConfig} from '../../lib/utils.js';
+import {type XoConfigItem} from '../../lib/types.js';
+import {allFilesGlob, jsFilesGlob, tsFilesGlob} from '../../lib/constants.js';
+
+const test = _test as TestFn<{cwd: string; files: string[]}>;
+
+// These tests are designed to validate the functionality of the utility functions in the `utils.js` file.
+// These utility functions are used together in xo in a specific way, so the tests are structured to ensure that they work correctly in that context.
+// each test checks the integration of the utility functions together, rather than testing them in isolation.
+
+test.beforeEach(t => {
+	// Set a fake working directory for the tests
+	t.context.cwd = '/path/to/project';
+	// Represents a set of files in a project directory, including all supported TypeScript and JavaScript files.
+	t.context.files = [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+		'/path/to/project/index.js',
+		'/path/to/project/index.test.js',
+		'/path/to/project/index.mjs',
+		'/path/to/project/index.cjs',
+		'/path/to/project/src/index.js',
+		'/path/to/project/src/index.test.js',
+		'/path/to/project/src/index.mjs',
+		'/path/to/project/src/index.cjs',
+		'/path/to/project/index.jsx',
+	];
+});
+
+test('empty config', t => {
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig([]);
+
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+
+	t.deepEqual(matchedFiles, [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+	], 'Only TypeScript files should be matched');
+});
+
+test('config with no "files" and @typescript-eslint rules set to "off"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'off',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+	], 'Only TypeScript files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "0"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': 0,
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+	], 'Only TypeScript files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "[off]"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': ['off'],
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+	], 'Only TypeScript files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "[0]"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': [0],
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+	], 'Only TypeScript files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "warn"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'warn',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "1"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': 1,
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "[warn]"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': ['warn'],
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "[1]"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': [1],
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "2"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': 2,
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "[error]"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': ['error'],
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+test('config with no "files" and @typescript-eslint rules set to "[2]"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			rules: {
+				'@typescript-eslint/no-unused-vars': [2],
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+
+test('config with js "files" glob and @typescript-eslint rules set to "off"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: ['**/*.js'],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'off',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+	], 'Only TypeScript files should be matched');
+});
+
+test('config with js "files" glob and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: [jsFilesGlob],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+
+test('config with mixed "files" glob and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: [allFilesGlob],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, t.context.files, 'All files should be matched');
+});
+
+test('config with mixed "files" glob filtered and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: ['**/*.{js,ts}'],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles.sort(), [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/index.js',
+		'/path/to/project/index.test.js',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+		'/path/to/project/src/index.js',
+		'/path/to/project/src/index.test.js',
+	].sort(), 'All Ts files and only .js files should be matched');
+});
+
+test('config with mixed relative glob "files" and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: ['./src/*.{js,ts}'],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles.sort(), [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+		'/path/to/project/src/index.js',
+		'/path/to/project/src/index.test.js',
+	].sort(), 'All Ts files and only .js files in src dir should be matched');
+});
+
+test('config with mixed relative trickier glob "files" and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: ['./src/*.{j,t}s'],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles.sort(), [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+		'/path/to/project/src/index.js',
+		'/path/to/project/src/index.test.js',
+	].sort(), 'All Ts files and only .js files in src dir should be matched');
+});
+
+test('config with mixed relative filepath "files" and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: ['./src/index.js'],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles.sort(), [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+		'/path/to/project/src/index.js',
+	].sort(), 'All Ts files and single .js files in src dir should be matched');
+});
+
+test('config with js glob "files" and @typescript-eslint rules set to "error" and ignores a file', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			files: ['*.js'],
+			ignores: ['index.test.js'],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles.sort(), [
+		'/path/to/project/index.ts',
+		'/path/to/project/index.test.ts',
+		'/path/to/project/index.mts',
+		'/path/to/project/index.cts',
+		'/path/to/project/index.tsx',
+		'/path/to/project/src/index.ts',
+		'/path/to/project/src/index.test.ts',
+		'/path/to/project/src/index.mts',
+		'/path/to/project/src/index.cts',
+		'/path/to/project/index.js',
+	].sort(), 'All Ts files and .js files in root dir should be matched');
+});
+
+test('config with custom languageOptions and @typescript-eslint rules set to "error"', t => {
+	const xoConfig: XoConfigItem[] = [
+		// Base config needs to be the first item in the array
+		{},
+		{
+			languageOptions: {
+				// @ts-expect-error - This is a test, parserOptions.project just needs to be set
+				parser: '@typescript-eslint/parser',
+				parserOptions: {
+					project: './tsconfig.json',
+				},
+			},
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'error',
+			},
+		},
+	];
+	const {tsFilesGlob: additionalTsFilesGlob, tsFilesIgnoresGlob} = preProcessXoConfig(xoConfig);
+	const globs = [tsFilesGlob, ...additionalTsFilesGlob];
+	const matchedFiles = matchFilesForTsConfig(t.context.cwd, t.context.files, globs, tsFilesIgnoresGlob);
+	t.deepEqual(matchedFiles, [], 'No files should be matched');
+});


### PR DESCRIPTION
This PR:
- closes #813 by allowing users to override our tsconfig handling by setting their own `languageOptions.parserOptions.project` and opt out of our tsconfig handling
- closes #807 by applying @typescript-eslint rules to js files if ts rules are _turned on_ in the config. Only applies to those specific files specified by `files` option (or all files if no `files` set).
- documents the changes
- adds lots of tests around glob matching for the above changes