### PR TITLE
Fix `indent-binary-ops` configuration for spaces

### DIFF
--- a/lib/xo-to-eslint.ts
+++ b/lib/xo-to-eslint.ts
@@ -62,10 +62,12 @@ export function xoToEslintConfig(flatXoConfig: XoConfigItem[] | undefined, {pret
 				// eslint-disable-next-line @typescript-eslint/naming-convention
 				{SwitchCase: 1},
 			];
+			eslintConfigItem.rules['@stylistic/indent-binary-ops'] = ['error', spaces];
 		} else if (xoConfigItem.space === false) {
 			// If a user sets this to false for a small subset of files for some reason,
-			// then we need to set them back to their original values.
+			// then we need to set them back to their oindent-binary-ops riginal values.
 			eslintConfigItem.rules['@stylistic/indent'] = configXoTypescript[1]?.rules?.['@stylistic/indent'];
+			eslintConfigItem.rules['@stylistic/indent-binary-ops'] = configXoTypescript[1]?.rules?.['@stylistic/indent-binary-ops'];
 		}
 
 		if (xoConfigItem.react) {

--- a/lib/xo-to-eslint.ts
+++ b/lib/xo-to-eslint.ts
@@ -65,7 +65,7 @@ export function xoToEslintConfig(flatXoConfig: XoConfigItem[] | undefined, {pret
 			eslintConfigItem.rules['@stylistic/indent-binary-ops'] = ['error', spaces];
 		} else if (xoConfigItem.space === false) {
 			// If a user sets this to false for a small subset of files for some reason,
-			// then we need to set them back to their oindent-binary-ops riginal values.
+			// then we need to set them back to their original values.
 			eslintConfigItem.rules['@stylistic/indent'] = configXoTypescript[1]?.rules?.['@stylistic/indent'];
 			eslintConfigItem.rules['@stylistic/indent-binary-ops'] = configXoTypescript[1]?.rules?.['@stylistic/indent-binary-ops'];
 		}

--- a/test/xo-to-eslint.test.ts
+++ b/test/xo-to-eslint.test.ts
@@ -24,6 +24,7 @@ test('base config rules', t => {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		{SwitchCase: 1},
 	]);
+	t.deepEqual(getJsRule(flatConfig, '@stylistic/indent-binary-ops'), ['error', 'tab']);
 	t.deepEqual(getJsRule(flatConfig, '@stylistic/semi'), ['error', 'always']);
 	t.deepEqual(getJsRule(flatConfig, '@stylistic/quotes'), ['error', 'single']);
 });
@@ -37,6 +38,7 @@ test('empty config rules', t => {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		{SwitchCase: 1},
 	]);
+	t.deepEqual(getJsRule(flatConfig, '@stylistic/indent-binary-ops'), ['error', 'tab']);
 	t.deepEqual(getJsRule(flatConfig, '@stylistic/semi'), ['error', 'always']);
 	t.deepEqual(getJsRule(flatConfig, '@stylistic/quotes'), ['error', 'single']);
 });
@@ -50,6 +52,7 @@ test('config with space option', t => {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		{SwitchCase: 1},
 	]);
+	t.deepEqual(getJsRule(flatConfig, '@stylistic/indent-binary-ops'), ['error', 2]);
 });
 
 test('config with semi false option', t => {

--- a/test/xo/lint-files.test.ts
+++ b/test/xo/lint-files.test.ts
@@ -92,7 +92,7 @@ test('flat config > ts > semi > no tsconfig', async t => {
 	t.is(results?.[0]?.messages?.[0]?.ruleId, '@stylistic/semi');
 });
 
-test('flat config > js > space', async t => {
+test.only('flat config > js > space', async t => {
 	const filePath = path.join(t.context.cwd, 'test.js');
 
 	await fs.writeFile(
@@ -114,13 +114,18 @@ test('flat config > js > space', async t => {
 		dedent`
 			export function foo() {
 				console.log('hello');
-			}\n
+			}
+
+			console.log('hello'
+				+ 'world');\n
 		`,
 	);
 	const {results} = await xo.lintFiles();
-	t.is(results?.[0]?.messages.length, 1);
+	t.is(results?.[0]?.messages.length, 2);
 	t.is(results?.[0]?.messages?.[0]?.messageId, 'wrongIndentation');
 	t.is(results?.[0]?.messages?.[0]?.ruleId, '@stylistic/indent');
+	t.is(results?.[0]?.messages?.[1]?.messageId, 'wrongIndentation');
+	t.is(results?.[0]?.messages?.[1]?.ruleId, '@stylistic/indent-binary-ops');
 });
 
 test('flat config > ts > space', async t => {
@@ -134,6 +139,9 @@ test('flat config > ts > space', async t => {
 			    space: true
 			  }
 			];\n
+
+			console.log('hello'
+				+ 'world');\n
 		`,
 		'utf8',
 	);
@@ -148,7 +156,9 @@ test('flat config > ts > space', async t => {
 		`,
 	);
 	const {results} = await xo.lintFiles();
-	t.is(results?.[0]?.messages.length, 1);
+	t.is(results?.[0]?.messages.length, 2);
 	t.is(results?.[0]?.messages?.[0]?.messageId, 'wrongIndentation');
 	t.is(results?.[0]?.messages?.[0]?.ruleId, '@stylistic/indent');
+	t.is(results?.[0]?.messages?.[1]?.messageId, 'wrongIndentation');
+	t.is(results?.[0]?.messages?.[1]?.ruleId, '@stylistic/indent-binary-ops');
 });

--- a/test/xo/lint-files.test.ts
+++ b/test/xo/lint-files.test.ts
@@ -92,7 +92,7 @@ test('flat config > ts > semi > no tsconfig', async t => {
 	t.is(results?.[0]?.messages?.[0]?.ruleId, '@stylistic/semi');
 });
 
-test.only('flat config > js > space', async t => {
+test('flat config > js > space', async t => {
 	const filePath = path.join(t.context.cwd, 'test.js');
 
 	await fs.writeFile(
@@ -139,9 +139,6 @@ test('flat config > ts > space', async t => {
 			    space: true
 			  }
 			];\n
-
-			console.log('hello'
-				+ 'world');\n
 		`,
 		'utf8',
 	);
@@ -152,7 +149,10 @@ test('flat config > ts > space', async t => {
 		dedent`
 			export function foo() {
 				console.log('hello');
-			}\n
+			}
+
+			console.log('hello'
+				+ 'world');\n
 		`,
 	);
 	const {results} = await xo.lintFiles();


### PR DESCRIPTION
### How to reproduce

Set `space: true` or `space: 2` in the `xo.config.js`, and use the code below for linting:

```js
console.log('hello'
  + 'world');
```

### Actual behavior

XO will report an `Expected indentation of 1 tab (@stylistic/indent-binary-ops)` error.

### Expected behavior

The linting process should pass.

### Solution

I've added the `@stylistic/indent-binary-ops` rule below the `@stylistic/indent`.