### PR TITLE
Add support for Vue, Svelte, and Astro file extensions

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -22,11 +22,13 @@ export const tsExtensions = ['ts', 'tsx', 'cts', 'mts'];
 
 export const jsExtensions = ['js', 'jsx', 'mjs', 'cjs'];
 
+export const frameworkExtensions = ['vue', 'svelte', 'astro'];
+
 export const jsFilesGlob = `**/*.{${jsExtensions.join(',')}}`;
 
 export const tsFilesGlob = `**/*.{${tsExtensions.join(',')}}`;
 
-export const allExtensions = [...jsExtensions, ...tsExtensions];
+export const allExtensions = [...jsExtensions, ...tsExtensions, ...frameworkExtensions];
 
 export const allFilesGlob = `**/*.{${allExtensions.join(',')}}`;
 

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Simply run `$ npm init xo` (with any options) to add XO to create an `xo.config.
 
 ## Config
 
-You can configure XO options by creating an `xo.config.js` or an `xo.config.ts` file in the root directory of your project, or you can add an `xo` field to your `package.json`. XO supports all js/ts file extensions (js,cjs,mjs,ts,cts,mts) automatically. A XO config is an extension of ESLint's Flat Config. Like ESLint, an XO config exports an array of XO config objects. XO config objects extend [ESLint Configuration Objects](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-objects). This means all the available configuration params for ESLint also work for `XO`. However, `XO` enhances and adds extra params to the configuration objects to make them easier to work with.
+You can configure XO options by creating an `xo.config.js` or an `xo.config.ts` file in the root directory of your project, or you can add an `xo` field to your `package.json`. XO supports all js/ts file extensions (js,cjs,mjs,ts,cts,mts) and popular framework extensions (vue,svelte,astro) automatically. A XO config is an extension of ESLint's Flat Config. Like ESLint, an XO config exports an array of XO config objects. XO config objects extend [ESLint Configuration Objects](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-objects). This means all the available configuration params for ESLint also work for `XO`. However, `XO` enhances and adds extra params to the configuration objects to make them easier to work with.
 
 ### Config types
 
@@ -137,7 +137,7 @@ export default [...] satisfies import('xo').FlatXoConfig
 ### files
 
 Type: `string | string[] | undefined`\
-Default: `**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}`
+Default: `**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,vue,svelte,astro}`
 
 A glob or array of glob strings which the config object will apply. By default `XO` will apply the configuration to [all files](lib/constants.ts).
 


### PR DESCRIPTION
XO now automatically discovers and lints `.vue`, `.svelte`, and `.astro` files when running without arguments. This resolves the limitation where users had to explicitly pass these file patterns on the command line even when they were configured in the config file.

Fixes #843