### PR TITLE
fix: error `ERR_MODULE_NOT_FOUND` from d21ab16

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
 	"files": [
 		"dist/lib/*.js",
 		"dist/lib/*.d.ts",
+		"dist/lib/rules/*.js",
+		"dist/lib/rules/*.d.ts",
 		"dist/*.js",
 		"dist/*.d.ts"
 	],


### PR DESCRIPTION
Fixes the following error when using 2.0.0.

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/projects/eslint-config/node_modules/xo/dist/lib/rules/no-use-extend-native.js' imported from /projects/eslint-config/node_modules/xo/dist/lib/config.js
```

@sindresorhus 