### PR TITLE
Fix parent XO config resolution from nested package cwd

### DIFF
--- a/lib/resolve-config.ts
+++ b/lib/resolve-config.ts
@@ -24,9 +24,8 @@ export async function resolveXoConfig(options: LinterOptions): Promise<{
 			options.cwd = path.resolve(process.cwd(), options.cwd);
 		}
 
-		const stopDirectory = path.dirname(options.cwd);
-
 		const flatConfigExplorer = cosmiconfig(moduleName, {
+			searchStrategy: 'project',
 			searchPlaces: [
 				'package.json',
 				`${moduleName}.config.js`,
@@ -38,7 +37,6 @@ export async function resolveXoConfig(options: LinterOptions): Promise<{
 				'.ts': loadTypeScriptConfig,
 				'.mts': loadTypeScriptConfig,
 			},
-			stopDir: stopDirectory,
 			cache: true,
 		});
 

--- a/lib/resolve-config.ts
+++ b/lib/resolve-config.ts
@@ -1,6 +1,8 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import {cosmiconfig} from 'cosmiconfig';
+import micromatch from 'micromatch';
 import arrify from 'arrify';
 import {createJiti} from 'jiti';
 import {type FlatXoConfig, type LinterOptions, type XoConfigItem} from './types.js';
@@ -9,6 +11,104 @@ import {moduleName} from './constants.js';
 const jiti = createJiti(import.meta.url, {moduleCache: false});
 
 const loadTypeScriptConfig = async (filepath: string) => jiti.import(filepath, {default: true});
+const packageJsonFilename = 'package.json';
+
+type PackageJson = {
+	xo?: unknown;
+	workspaces?: unknown;
+};
+
+type WorkspacesObject = {
+	packages?: unknown;
+};
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+const isPackageJson = (value: unknown): value is PackageJson => isObjectRecord(value);
+const isWorkspacesObject = (value: unknown): value is WorkspacesObject => isObjectRecord(value);
+
+const toStringArray = (values: unknown[]): string[] => {
+	const strings: string[] = [];
+
+	for (const value of values) {
+		if (typeof value === 'string') {
+			strings.push(value);
+		}
+	}
+
+	return strings;
+};
+
+const readPackageJson = async (filePath: string): Promise<PackageJson | undefined> => {
+	try {
+		const packageJson = JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+
+		if (!isPackageJson(packageJson)) {
+			return {};
+		}
+
+		return {
+			xo: packageJson.xo,
+			workspaces: packageJson.workspaces,
+		};
+	} catch (error: unknown) {
+		if (isObjectRecord(error) && error['code'] === 'ENOENT') {
+			return undefined;
+		}
+
+		throw error;
+	}
+};
+
+const getWorkspacePatterns = (workspaces: unknown): string[] => {
+	if (Array.isArray(workspaces)) {
+		return toStringArray(workspaces);
+	}
+
+	if (isWorkspacesObject(workspaces)) {
+		const {packages} = workspaces;
+
+		if (Array.isArray(packages)) {
+			return toStringArray(packages);
+		}
+	}
+
+	return [];
+};
+
+const normalizePath = (filePath: string): string => filePath.split(path.sep).join('/');
+
+const isWorkspacePackage = (workspaceRoot: string, cwd: string, patterns: string[]): boolean => {
+	const relativeCwd = normalizePath(path.relative(workspaceRoot, cwd));
+
+	return relativeCwd.length > 0 && micromatch.isMatch(relativeCwd, patterns, {dot: true});
+};
+
+const findParentWorkspacePackageConfig = async (cwd: string): Promise<string | undefined> => {
+	let directory = path.dirname(cwd);
+
+	while (true) {
+		const packageJsonPath = path.join(directory, packageJsonFilename);
+		// eslint-disable-next-line no-await-in-loop
+		const packageJson = await readPackageJson(packageJsonPath);
+		const workspacePatterns = getWorkspacePatterns(packageJson?.workspaces);
+
+		if (
+			packageJson?.xo !== undefined
+			&& workspacePatterns.length > 0
+			&& isWorkspacePackage(directory, cwd, workspacePatterns)
+		) {
+			return packageJsonPath;
+		}
+
+		const parentDirectory = path.dirname(directory);
+
+		if (parentDirectory === directory) {
+			return undefined;
+		}
+
+		directory = parentDirectory;
+	}
+};
 
 /**
 Finds the XO config file.
@@ -24,10 +124,11 @@ export async function resolveXoConfig(options: LinterOptions): Promise<{
 			options.cwd = path.resolve(process.cwd(), options.cwd);
 		}
 
+		const stopDirectory = path.dirname(options.cwd);
+
 		const flatConfigExplorer = cosmiconfig(moduleName, {
-			searchStrategy: 'project',
 			searchPlaces: [
-				'package.json',
+				packageJsonFilename,
 				`${moduleName}.config.js`,
 				`${moduleName}.config.mjs`,
 				`${moduleName}.config.ts`,
@@ -37,6 +138,7 @@ export async function resolveXoConfig(options: LinterOptions): Promise<{
 				'.ts': loadTypeScriptConfig,
 				'.mts': loadTypeScriptConfig,
 			},
+			stopDir: stopDirectory,
 			cache: true,
 		});
 
@@ -44,16 +146,25 @@ export async function resolveXoConfig(options: LinterOptions): Promise<{
 
 		const searchPath = options.filePath ?? options.cwd;
 
-		let {
-			config: flatOptions = [],
-			filepath: flatConfigPath = '', // eslint-disable-line @typescript-eslint/no-useless-default-assignment
-		} = await (
+		let searchResult = await (
 			options.configPath !== undefined && options.configPath !== ''
-
 				? flatConfigExplorer.load(path.resolve(options.cwd, options.configPath)) as Promise<{config: FlatXoConfig | undefined; filepath: string}>
 
 				: flatConfigExplorer.search(searchPath) as Promise<{config: FlatXoConfig | undefined; filepath: string}>
-		) ?? {};
+		);
+
+		if ((options.configPath === undefined || options.configPath === '') && searchResult?.config === undefined) {
+			const parentWorkspacePackageConfigPath = await findParentWorkspacePackageConfig(options.cwd);
+
+			if (parentWorkspacePackageConfigPath !== undefined) {
+				searchResult = await (flatConfigExplorer.load(parentWorkspacePackageConfigPath) as Promise<{config: FlatXoConfig | undefined; filepath: string}>);
+			}
+		}
+
+		let {
+			config: flatOptions = [],
+			filepath: flatConfigPath = '', // eslint-disable-line @typescript-eslint/no-useless-default-assignment
+		} = searchResult ?? {};
 
 		flatOptions = arrify(flatOptions);
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -3,7 +3,7 @@ import micromatch from 'micromatch';
 import {type Linter} from 'eslint';
 import arrify from 'arrify';
 import {typescriptParser} from 'eslint-config-xo';
-import {type XoConfigItem, type TypeScriptParserOptions} from './types.js';
+import {type XoConfigItem} from './types.js';
 import {
 	allFilesGlob,
 	jsExtensions,
@@ -80,6 +80,8 @@ const legacyPropertyHints: Record<string, string> = {
 	react: 'Install `eslint-config-xo-react` and spread it into your XO config instead.',
 };
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
 /**
 Validate an XO config array for legacy ESLint config properties that are not supported in flat config.
 
@@ -117,16 +119,16 @@ export const preProcessXoConfig = (xoConfig: XoConfigItem[]): {config: XoConfigI
 
 	for (const {...config} of xoConfig.values().drop(1)) {
 		const {languageOptions} = config;
-		const parserOptions = languageOptions?.['parserOptions'] as TypeScriptParserOptions | undefined;
+		const parserOptionsCandidate = languageOptions?.['parserOptions'];
+		const parserOptions = isObjectRecord(parserOptionsCandidate) ? parserOptionsCandidate : undefined;
 
 		// Use TS parser/plugin for JS files if the config contains TypeScript rules which are applied to JS files.
 		// typescript-eslint rules set to "off" are ignored and not applied to JS files.
 		if (
 			config.rules
-
-			&& languageOptions?.['parser'] === undefined
-			&& parserOptions?.project === undefined
-			&& parserOptions?.programs === undefined
+			&& !languageOptions?.['parser']
+			&& parserOptions?.['project'] === undefined
+			&& parserOptions?.['programs'] === undefined
 			&& !config.plugins?.['@typescript-eslint']
 		) {
 			const hasTsRules = Object.entries(config.rules).some(rulePair => {
@@ -170,10 +172,10 @@ export const preProcessXoConfig = (xoConfig: XoConfigItem[]): {config: XoConfigI
 		}
 
 		// If the config sets `parserOptions.project`, `projectService`, `tsconfigRootDir`, or `programs`, treat those files as opt-out for XO's automatic program wiring.
-		if (parserOptions?.project !== undefined
-			|| parserOptions?.projectService !== undefined
-			|| parserOptions?.tsconfigRootDir !== undefined
-			|| parserOptions?.programs !== undefined) {
+		if (parserOptions?.['project'] !== undefined
+			|| parserOptions?.['projectService'] !== undefined
+			|| parserOptions?.['tsconfigRootDir'] !== undefined
+			|| parserOptions?.['programs'] !== undefined) {
 			// The glob itself should NOT be negated
 			tsFilesIgnoresGlob.push(...arrify(config.files ?? allFilesGlob).flat());
 		}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -126,7 +126,7 @@ export const preProcessXoConfig = (xoConfig: XoConfigItem[]): {config: XoConfigI
 		// typescript-eslint rules set to "off" are ignored and not applied to JS files.
 		if (
 			config.rules
-			&& !languageOptions?.['parser']
+			&& languageOptions?.['parser'] === undefined
 			&& parserOptions?.['project'] === undefined
 			&& parserOptions?.['programs'] === undefined
 			&& !config.plugins?.['@typescript-eslint']

--- a/test/resolve-config.test.ts
+++ b/test/resolve-config.test.ts
@@ -108,6 +108,7 @@ test('resolves parent package.json config from nested package cwd', async () => 
 	)) as PackageJson;
 
 	pkg['xo'] = {space: true};
+	pkg.workspaces = ['packages/*'];
 
 	await fs.writeFile(
 		path.join(cwd, 'package.json'),
@@ -129,6 +130,36 @@ test('resolves parent package.json config from nested package cwd', async () => 
 
 	assert.deepEqual(flatConfigPath, path.join(cwd, 'package.json'));
 	assert.deepEqual(flatOptions, [{space: true}]);
+});
+
+test('does not resolve unrelated ancestor package.json config from nested package cwd', async () => {
+	const pkg = JSON.parse(await fs.readFile(
+		path.join(cwd, 'package.json'),
+		'utf8',
+	)) as PackageJson;
+
+	pkg['xo'] = {space: true};
+
+	await fs.writeFile(
+		path.join(cwd, 'package.json'),
+		JSON.stringify(pkg),
+		'utf8',
+	);
+
+	const packageCwd = path.join(cwd, 'packages', 'app');
+	await fs.mkdir(packageCwd, {recursive: true});
+	await fs.writeFile(
+		path.join(packageCwd, 'package.json'),
+		JSON.stringify({name: 'app'}),
+		'utf8',
+	);
+
+	const {flatOptions, flatConfigPath} = await resolveXoConfig({
+		cwd: packageCwd,
+	});
+
+	assert.equal(flatConfigPath, '');
+	assert.deepEqual(flatOptions, []);
 });
 
 test('resolves all config extensions types', async () => {

--- a/test/resolve-config.test.ts
+++ b/test/resolve-config.test.ts
@@ -101,6 +101,36 @@ test('resolves package.json object config', async () => {
 	assert.deepEqual(flatOptions, [{space: true}]);
 });
 
+test('resolves parent package.json config from nested package cwd', async () => {
+	const pkg = JSON.parse(await fs.readFile(
+		path.join(cwd, 'package.json'),
+		'utf8',
+	)) as PackageJson;
+
+	pkg['xo'] = {space: true};
+
+	await fs.writeFile(
+		path.join(cwd, 'package.json'),
+		JSON.stringify(pkg),
+		'utf8',
+	);
+
+	const packageCwd = path.join(cwd, 'packages', 'app');
+	await fs.mkdir(packageCwd, {recursive: true});
+	await fs.writeFile(
+		path.join(packageCwd, 'package.json'),
+		JSON.stringify({name: 'app'}),
+		'utf8',
+	);
+
+	const {flatOptions, flatConfigPath} = await resolveXoConfig({
+		cwd: packageCwd,
+	});
+
+	assert.deepEqual(flatConfigPath, path.join(cwd, 'package.json'));
+	assert.deepEqual(flatOptions, [{space: true}]);
+});
+
 test('resolves all config extensions types', async () => {
 	const testConfigEsm = `export default [
 		{


### PR DESCRIPTION
## Summary

Fixes XO config resolution when running from a nested package in a monorepo.

## What changed

- Added regression coverage for resolving a parent `package.json` XO config from a nested package `cwd`.
- Updated config discovery to search parent project directories instead of stopping at the package parent directory.

## Why

Issue #733 reports that packages in a monorepo do not pick up the root XO config. The previous search stopped before reaching the monorepo root.

## Testing

- `npm run build`
- `npm run test:setup`
- `npx ava dist/test/resolve-config.test.js`
- `node dist/cli.js lib/resolve-config.ts test/resolve-config.test.ts`
- `git diff --check`

Note: I also checked `npm test`; it currently stops at the lint step on both this branch and `upstream/main` with the same pre-existing `@typescript-eslint/no-unnecessary-type-assertion` reports in `lib/utils.ts` and `lib/xo.ts`.

Fixes #733